### PR TITLE
Hotfix/ audio rtp/process termination handling

### DIFF
--- a/juturna/nodes/source/_audio_rtp/audio_rtp.py
+++ b/juturna/nodes/source/_audio_rtp/audio_rtp.py
@@ -80,7 +80,6 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
             ['sh', self.ffmpeg_launcher],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             bufsize=64536)
 
         self._monitor_thread = threading.Thread(target=self.monitor_process, args=(self._ffmpeg_proc,))

--- a/juturna/nodes/source/_audio_rtp/audio_rtp.py
+++ b/juturna/nodes/source/_audio_rtp/audio_rtp.py
@@ -105,10 +105,17 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
             time.sleep(2)
 
             self._ffmpeg_proc.terminate()
-            self._ffmpeg_proc.wait()
+            try:
+                self._ffmpeg_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logging.warning("ffmpeg process did not terminate in time, killing it.")
+                self._ffmpeg_proc.kill()
+                self._ffmpeg_proc.wait()
             self._ffmpeg_proc = None
 
-            self._monitor_thread.join()
+            self._monitor_thread.join(timeout=5)
+            if self._monitor_thread.is_alive():
+                logging.warning("Monitor thread did not exit in time.")
 
         except Exception:
             ...

--- a/juturna/nodes/source/_audio_rtp/audio_rtp.py
+++ b/juturna/nodes/source/_audio_rtp/audio_rtp.py
@@ -25,6 +25,7 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
                  audio_rate: int,
                  block_size: int,
                  channels: int,
+                 process_log_level: str,
                  payload_type: int):
         """
         Parameters
@@ -40,6 +41,8 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
             Size of the audio block to sample, in seconds.
         channels : int
             Number of source audio channels.
+        process_log_level : str
+            Log level for the ffmpeg process.
         payload_type : int
             Payload type for the RTP stream.
         """
@@ -57,6 +60,7 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
 
         self._rec_host = rec_host
         self._rec_port = rec_port
+        self._process_log_level = process_log_level
 
         self._sdp_file_path = None
         self._ffmpeg_proc = None
@@ -167,6 +171,7 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
             self.prepare_template(
                 AudioRTP._FFMPEG_TEMPLATE_NAME, '_ffmpeg_launcher.sh', {
                     '_sdp_location': self.sdp_descriptor,
+                    '_process_log_level': self._process_log_level,
                     '_audio_rate': self._audio_rate })
 
     def monitor_process(self, proc):

--- a/juturna/nodes/source/_audio_rtp/audio_rtp.py
+++ b/juturna/nodes/source/_audio_rtp/audio_rtp.py
@@ -82,7 +82,8 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
             stdout=subprocess.PIPE,
             bufsize=64536)
 
-        self._monitor_thread = threading.Thread(target=self.monitor_process, args=(self._ffmpeg_proc,))
+        self._monitor_thread = threading.Thread(target=self.monitor_process,
+                                                args=(self._ffmpeg_proc,))
         self._monitor_thread.start()
 
         self.set_source(lambda: Message[BytesPayload](
@@ -108,11 +109,13 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
                 self._ffmpeg_proc.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 logging.warning("ffmpeg process did not terminate in time, killing it.")
+                
                 self._ffmpeg_proc.kill()
                 self._ffmpeg_proc.wait()
             self._ffmpeg_proc = None
 
             self._monitor_thread.join(timeout=5)
+            
             if self._monitor_thread.is_alive():
                 logging.warning("Monitor thread did not exit in time.")
 
@@ -185,6 +188,7 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
         self.clear_source()
         logging.debug(f'{self.name} subprocess terminates with code: {proc.returncode} - current node status: {self.status.name}')
         time.sleep(5)
+        
         if self.status == ComponentStatus.RUNNING:
             logging.info(f'{self.name} subprocess is respawning in 5 seconds')
             self.stop()

--- a/juturna/nodes/source/_audio_rtp/audio_rtp.py
+++ b/juturna/nodes/source/_audio_rtp/audio_rtp.py
@@ -112,6 +112,7 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
                 
                 self._ffmpeg_proc.kill()
                 self._ffmpeg_proc.wait()
+                
             self._ffmpeg_proc = None
 
             self._monitor_thread.join(timeout=5)
@@ -186,11 +187,14 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
     def monitor_process(self, proc):
         proc.wait()
         self.clear_source()
-        logging.debug(f'{self.name} subprocess terminates with code: {proc.returncode} - current node status: {self.status.name}')
+        logging.debug(f'{self.name} subprocess terminates with code: \
+            {proc.returncode} - current node status: {self.status.name}')
+
         time.sleep(5)
         
         if self.status == ComponentStatus.RUNNING:
             logging.info(f'{self.name} subprocess is respawning in 5 seconds')
+            
             self.stop()
             time.sleep(5)
             self.start()

--- a/juturna/nodes/source/_audio_rtp/config.toml
+++ b/juturna/nodes/source/_audio_rtp/config.toml
@@ -4,6 +4,7 @@ rec_port = "auto"
 audio_rate = 16000
 block_size = 3
 channels = 2
+process_log_level = "quiet"
 payload_type = 97
 
 [meta]

--- a/juturna/nodes/source/_audio_rtp/ffmpeg_launcher.sh.template
+++ b/juturna/nodes/source/_audio_rtp/ffmpeg_launcher.sh.template
@@ -5,5 +5,5 @@ ffmpeg \
     -ac 2 \
     -acodec pcm_s16le \
     -ar $_audio_rate \
-    -loglevel quiet \
+    -loglevel $_process_log_level \
     pipe:


### PR DESCRIPTION
This PR enhances the `_audio_rtp` node by introducing two main features:

1. **Subprocess state monitoring & restart**
The node now actively monitors the subprocess.
When the subprocess terminates, a grace period is applied before taking action.
If, after this grace period, the node state is still `RUNNING`, the subprocess is automatically restarted.

2. **Configurable logging level for ffmpeg**
Added support to configure the log level of the underlying ffmpeg subprocess.
This makes it easier to adjust verbosity for debugging or production use.

**Why**
Improves fault tolerance by ensuring the subprocess is relaunched when needed.
Provides better observability and flexibility in managing ffmpeg logs.