### PR TITLE
fix(audio_rtp): removing timeout from monitor_thread join

### DIFF
--- a/juturna/nodes/source/_audio_rtp/audio_rtp.py
+++ b/juturna/nodes/source/_audio_rtp/audio_rtp.py
@@ -115,11 +115,8 @@ class AudioRTP(BaseNode[BytesPayload, AudioPayload]):
                 
             self._ffmpeg_proc = None
 
-            self._monitor_thread.join(timeout=5)
+            self._monitor_thread.join()
             
-            if self._monitor_thread.is_alive():
-                logging.warning("Monitor thread did not exit in time.")
-
         except Exception:
             ...
 


### PR DESCRIPTION
Removed the `timeout` from the `monitor_thread.join` in the `_audio_rtp` node.
The monitoring thread was taking too long to terminate, causing the join to fail consistently and leaving the thread hanging.
This led to subprocess restarts being triggered in a loop, preventing the parent process from shutting down properly.

**Note**
Timeout handling still needs further tuning to avoid unnecessary restarts and to ensure the shutdown time stays within ≤ 10s.