### PR TITLE
fix(transcriber_whispy): derive start_abs from size and sequence_number

### DIFF
--- a/plugins/nodes/proc/_transcriber_whispy/transcriber_whispy.py
+++ b/plugins/nodes/proc/_transcriber_whispy/transcriber_whispy.py
@@ -80,12 +80,15 @@ class TranscriberWhispy(BaseNode[AudioPayload, ObjectPayload]):
         with to_send.timeit(self.name):
             transcript = list(transcript)
 
+        word_start_abs = (self._data[0].meta['size'] * 
+                          self._data[0].meta['sequence_number'])
+
         word_list = [{
             'word': w.word,
             'start': float(w.start),
             'end': float(w.end),
-            'start_abs': float(w.start) + self._data[0].meta['start_abs'],
-            'end_abs': float(w.end) + self._data[0].meta['start_abs'],
+            'start_abs': float(w.start) + word_start_abs,
+            'end_abs': float(w.end) + word_start_abs,
             'probability': float(w.probability)
         } for segment in transcript for w in segment.words]
 
@@ -105,7 +108,8 @@ class TranscriberWhispy(BaseNode[AudioPayload, ObjectPayload]):
         accumulated_time = 0
 
         for m in buffer:
-            start_abs = m.meta['start_abs']
+            
+            start_abs = (m.meta['size'] * m.meta['sequence_number'])
             speech_offset_map = []
 
             for segment in m.meta['speech_timestamps']:


### PR DESCRIPTION
The `start_abs~ parameter is now computed inside the **whisper_transcriber** node.
Previously, the transcriber expected this parameter to be present in the upstream data, but its assignment in the VAD node’s output had been removed in [this commit](https://github.com/meetecho/juturna/commit/50fd0c2ed38fd80bf3f0be60bf03a813ffcef755?utm_source=chatgpt.com)
, causing failures.

As a side note:

- size and sequence_number are currently treated as optional fields across Payloads and may be missing between nodes.
- A further improvement would be to:
replace sequence_number with version, if it is meant to be a stable property of Payloads;
evaluate whether size should be promoted to a BasePayload property.