### PR TITLE
fix(cli): lazy-import uvicorn so non-HTTP commands don’t require http…

### DIFF
--- a/juturna/cli/commands/_juturna_service.py
+++ b/juturna/cli/commands/_juturna_service.py
@@ -1,7 +1,6 @@
 import pathlib
 import logging
 
-import uvicorn
 import fastapi
 import pydantic
 
@@ -95,6 +94,14 @@ def run(
 
     logger.info(f'service address: {host}:{port}')
 
+    # Lazy import so non-HTTP CLI commands don't require httpwrapper extras
+    try:
+        import uvicorn
+    except ImportError as e:
+        raise RuntimeError(
+             "Install juturna[httpwrapper] to use 'serve' (missing 'uvicorn')."
+        ) from e
+    
     uvicorn.run(
         'juturna.cli.commands._juturna_service:app',
         host=host,


### PR DESCRIPTION
…wrapper extras

Fixes #31

Moves `import uvicorn` from module top level into the `run()` path and adds a friendly message suggesting `pip install "juturna[httpwrapper]"` when uvicorn is missing. This prevents ModuleNotFoundError for CLI commands that don't need the HTTP stack.