### PR TITLE
fix(audio_rtp): (#32) enforcing integers to automatic port assignment

### DIFF
--- a/juturna/nodes/source/_audio_rtp/audio_rtp.py
+++ b/juturna/nodes/source/_audio_rtp/audio_rtp.py
@@ -21,7 +21,7 @@ class AudioRTP(Node[BytesPayload, AudioPayload]):
     def __init__(
         self,
         rec_host: str,
-        rec_port: int | str,
+        rec_port: int,
         audio_rate: int,
         block_size: int,
         channels: int,
@@ -35,15 +35,15 @@ class AudioRTP(Node[BytesPayload, AudioPayload]):
         ----------
         rec_host : str
             Hostname of the remote RTP server to receive audio from.
-        rec_port : int | str
-            Port of the RTP server to receive audio from. If set to "auto",
+        rec_port : int
+            Port of the RTP server to receive audio from. If set to 0,
             the port will be assigned automatically by the resource broker.
         audio_rate : int
-            Audio sample rate in Hz (samples per seconds).
+            Internal audio sample rate in Hz (samples per seconds).
         block_size : int
             Size of the audio block to sample, in seconds.
         channels : int
-            Number of source audio channels.
+            Number of internal audio channels.
         process_log_level : str
             Log level for the ffmpeg process.
         payload_type : int
@@ -80,7 +80,7 @@ class AudioRTP(Node[BytesPayload, AudioPayload]):
         self._monitor_thread = None
 
     def configure(self):
-        if self._rec_port == 'auto':
+        if self._rec_port == 0:
             self._rec_port = rb.get('port')
 
     def warmup(self):
@@ -209,6 +209,7 @@ class AudioRTP(Node[BytesPayload, AudioPayload]):
                 '_sdp_location': self.sdp_descriptor,
                 '_process_log_level': self._process_log_level,
                 '_audio_rate': self._audio_rate,
+                '_channels': self._channels,
             },
         )
 

--- a/juturna/nodes/source/_audio_rtp/config.toml
+++ b/juturna/nodes/source/_audio_rtp/config.toml
@@ -1,6 +1,6 @@
 [arguments]
 rec_host = "127.0.0.1"
-rec_port = "auto"
+rec_port = 0
 audio_rate = 16000
 block_size = 3
 channels = 2

--- a/juturna/nodes/source/_audio_rtp/ffmpeg_launcher.sh.template
+++ b/juturna/nodes/source/_audio_rtp/ffmpeg_launcher.sh.template
@@ -2,7 +2,7 @@ ffmpeg \
     -protocol_whitelist file,rtp,udp \
     -i $_sdp_location \
     -f s16le \
-    -ac 2 \
+    -ac $_channels \
     -acodec pcm_s16le \
     -ar $_audio_rate \
     -loglevel $_process_log_level \


### PR DESCRIPTION
and (#25) changing the config channels usage

- Disallowed using strings as port values.
- Replaced "auto" with 0 to select an ephemeral port automatically.
- Made the channels property dynamically control the channel count in the FFmpeg template.
- Updated both `config.toml` and `ffmpeg_launcher.sh.template` accordingly