### PR TITLE
Serialisation methods added to payloads

### DIFF
--- a/juturna/components/_message.py
+++ b/juturna/components/_message.py
@@ -92,15 +92,21 @@ class Message[T_Input]:
             'timers': self.timers,
         }
 
-    def to_json(self, encoder: typing.Callable | None = None) -> str:
+    def to_json(
+        self, encoder: typing.Callable | None = None, indent: int | None = None
+    ) -> str:
         """
-        Convert the message to a JSON string.
+        Convert the message to a JSON string. A custom encoder can be provided
+        to serialise non-serialisable content, otherwise the default serialize
+        method defined on the payload will be used.
 
         Parameters
         ----------
         encoder : callable, optional
             A custom JSON encoder. The default is None, which uses the default
             JSON encoder.
+        indent : int
+            Indentation level for the serialisation, Defaulted to None.
 
         Returns
         -------
@@ -108,7 +114,15 @@ class Message[T_Input]:
             The JSON string representation of the message.
 
         """
-        return json.dumps(self.to_dict(), default=encoder, indent=2)
+        use_encoder = encoder or (
+            self.payload.serialize if self.payload is not None else None
+        )
+
+        return json.dumps(
+            self.to_dict(),
+            default=use_encoder,
+            indent=indent,
+        )
 
     @property
     def creator(self) -> str | None:

--- a/juturna/payloads/_payloads.py
+++ b/juturna/payloads/_payloads.py
@@ -1,4 +1,6 @@
 import copy
+import math
+import json
 
 from typing import Self
 from dataclasses import dataclass
@@ -14,6 +16,10 @@ class BasePayload:
     def clone(self) -> Self:
         return copy.deepcopy(self)
 
+    @staticmethod
+    def serialize(obj):
+        return json.JSONEncoder.default(obj)
+
 
 @dataclass
 class AudioPayload(BasePayload):
@@ -22,6 +28,16 @@ class AudioPayload(BasePayload):
     channels: int = -1
     start: float = -1.0
     end: float = -1.0
+
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            'audio': obj.audio.tolist(),
+            'sampling_rate': obj.sampling_rate,
+            'channels': obj.channels,
+            'start': obj.start,
+            'end': obj.end,
+        }
 
 
 @dataclass
@@ -33,6 +49,17 @@ class ImagePayload(BasePayload):
     pixel_format: str = ''
     timestamp: float = -1.0
 
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            'image': obj.image.tolist(),
+            'width': obj.width,
+            'height': obj.height,
+            'depth': obj.depth,
+            'pixel_format': obj.pixel_format,
+            'timestamp': obj.timestamp,
+        }
+
 
 @dataclass
 class VideoPayload(BasePayload):
@@ -41,15 +68,32 @@ class VideoPayload(BasePayload):
     start: float = -1.0
     end: float = -1.0
 
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {
+            'video': [img.serialize() for img in obj.video],
+            'frames_per_second': obj.frames_per_second,
+            'start': obj.start,
+            'end': obj.end,
+        }
+
 
 @dataclass
 class BytesPayload(BasePayload):
     cnt: bytes = field(default_factory=lambda: b'')
 
+    @staticmethod
+    def serialize(obj) -> dict:
+        return {'cnt': obj.cnt.decode('utf-8')}
+
 
 @dataclass
 class Batch(BasePayload):
     messages: list[Message] = field(default_factory=lambda: list())
+
+    @staticmethod
+    def serialize(obj) -> list:
+        return [msg.serialize() for msg in obj.messages]
 
 
 @dataclass

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -5,6 +5,13 @@ import numpy as np
 
 from juturna.components import Message
 
+from juturna.payloads._payloads import AudioPayload
+from juturna.payloads._payloads import ImagePayload
+from juturna.payloads._payloads import VideoPayload
+from juturna.payloads._payloads import BytesPayload
+from juturna.payloads._payloads import Batch
+from juturna.payloads._payloads import ObjectPayload
+
 
 def test_message_init():
     msg = Message()
@@ -153,9 +160,9 @@ def test_message_to_json():
 
 def test_message_to_json_custom_encoder():
     msg = Message()
-    msg.payload = np.array([1, 2, 3])
+    msg.payload = AudioPayload(audio=np.ndarray(10))
 
-    json_str = msg.to_json(encoder=lambda x: x.tolist())
+    json_str = msg.to_json(encoder=lambda x: 'custom_serialised')
 
     assert isinstance(json_str, str)
     assert 'created_at' in json_str
@@ -165,7 +172,26 @@ def test_message_to_json_custom_encoder():
     assert 'meta' in json_str
     assert 'timers' in json_str
 
-    retrieved_payload = json.loads(json_str)['payload']
+    recoded = json.loads(json_str)
 
-    assert isinstance(retrieved_payload, list)
-    assert retrieved_payload == [1, 2, 3]
+    assert 'created_at' in recoded.keys()
+    assert 'creator' in recoded.keys()
+    assert 'version' in recoded.keys()
+    assert 'payload' in recoded.keys()
+    assert 'meta' in recoded.keys()
+    assert 'timers' in recoded.keys()
+
+    assert recoded['payload'] == 'custom_serialised'
+
+def test_message_serialisation():
+    test_payload = AudioPayload(
+        audio=np.ndarray(10),
+        sampling_rate=10,
+        channels=2,
+        start=0,
+        end=5
+    )
+
+    test_message = Message(creator='tester', version=7, payload=test_payload)
+
+    serialized = test_message.to_json()

--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -62,3 +62,47 @@ def test_object_payload():
 
     assert payload['prop_a'] == 'string'
     assert payload['prop_b'] == 10
+
+
+def test_serialize_audio():
+    test_waveform = [1, 2, 3, 4, 5]
+    test_audio = np.asarray(test_waveform, dtype=np.int8)
+
+    test_payload = AudioPayload(
+        audio=test_audio,
+        sampling_rate=100,
+        channels=1,
+        start=0,
+        end=5
+    )
+
+    serialized = AudioPayload.serialize(test_payload)
+
+    assert isinstance(serialized, dict)
+    assert serialized['audio'] == test_waveform
+    assert serialized['sampling_rate'] == 100
+    assert serialized['channels'] == 1
+    assert serialized['start'] == 0
+    assert serialized['end'] == 5
+
+
+def test_serialize_image():
+    test_frame = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+    test_image = np.asarray(test_frame, dtype=np.float32)
+
+    test_payload = ImagePayload(
+        image=test_image,
+        width=3,
+        height=3,
+        depth=1,
+        pixel_format='test_format'
+    )
+
+    serialized = ImagePayload.serialize(test_payload)
+
+    assert isinstance(serialized, dict)
+    np.testing.assert_array_equal(serialized['image'], test_image)
+    assert serialized['width'] == 3
+    assert serialized['height'] == 3
+    assert serialized['depth'] == 1
+    assert serialized['pixel_format'] == 'test_format'


### PR DESCRIPTION
As defined in #52 now payloads define their own serialisation strategy, so that when a message needs conversion into json string, their default serialize method will be invoked.