### PR TITLE
Fix: Node dump_json should be rewritten to use the latest json serialisation ( Issue #56)

### DIFF
--- a/juturna/components/_node.py
+++ b/juturna/components/_node.py
@@ -243,7 +243,7 @@ class Node[T_Input, T_Output]:
         dump_path = pathlib.Path(self.pipe_path, file_name)
 
         with open(dump_path, 'w') as f:
-            f.write(message.to_json(encoder=lambda x: x.tolist()))
+            f.write(message.to_json())
 
         return str(dump_path)
 


### PR DESCRIPTION
Fix: Remove default encoder from Node.dump_json method

## Description

The `dump_json` method in the base `Node` class was using a hardcoded encoder 
(`lambda x: x.tolist()`) that breaks serialization for payloads that don't have 
a `.tolist()` method (e.g., dataclass payloads like `AudioPayload`, `ImagePayload`).

Since payloads now have their own serialization logic (as implemented in #53), 
we should remove the default encoder and let `message.to_json()` use Python's 
default JSON encoder, which properly handles different payload types.

## Changes

- Removed the `encoder=lambda x: x.tolist()` parameter from `message.to_json()` 
  call in `Node.dump_json()` method
- Now relies on payloads' own serialization logic for proper JSON conversion

## Related Issues

Fixes #56