### PR TITLE
fix(docs): remove outdated LIFO queue documentation

### DIFF
--- a/docs/source/explain/nodes.rst
+++ b/docs/source/explain/nodes.rst
@@ -82,7 +82,13 @@ upstream.
 .. admonition:: The inbound queue (|version|-|release|)
    :class: :NOTE:
 
-   Nodes and Buffer classes now use FIFO (First-In, First-Out) queues as inbound message buffers. This update replaces the previous LIFO implementation to prevent message misordering. The inbound queue size is now configurable through the ``JUTURNA_MAX_QUEUE_SIZE`` environment variable (default: 999). Further refinements to the inbound queue might come in the future.
+   Nodes and Buffer classes now use FIFO (First-In, First-Out) queues. This
+   ensures messages are processed in the order they are produced, even when a
+   source node generates data faster than its descendants can consume it. The
+   previous LIFO-based design could reorder messages during such bursts, leading
+   to incorrect processing. Further refinements to the inbound queue may be
+   introduced in the future.
+
 
 The ``_update`` thread represents the node's processing engine. It consumes
 messages from the buffer in batches, not individually. This batching is where


### PR DESCRIPTION
## Description
This PR closes [#64](https://github.com/meetecho/juturna/issues/64).
Based on the changes introduced in [#60](https://github.com/meetecho/juturna/pull/60), it updates the outdated excerpt referencing LIFO queues in the threading model documentation

### Changes
- **`docs/source/explain/nodes.rst`**: Updated the documentation stub related to the inbound queue.

### Closes
[#64](https://github.com/meetecho/juturna/issues/64) 

### Additional Notes
[X] Locate the LIFO queue reference in the threading model documentation.
[X] Remove or update the outdated excerpt.
[X] Verify no other documentation sections reference the old LIFO queue implementation.