### PR TITLE
Reducing and resizing options added to image reader input node

### DIFF
--- a/plugins/nodes/source/_image_loader/config.toml
+++ b/plugins/nodes/source/_image_loader/config.toml
@@ -4,5 +4,7 @@ patterns = ["*"]
 recursive = false
 ignore_updates = true
 convert_rgb = true
+reduce_by = -1
+resize_by = [-1, -1]
 
 [meta]


### PR DESCRIPTION
### Description
As per #90, this PR brings the option to the image reader node to resize or reduce the input images.

**PR type**
Select all the labels that apply to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
The `image_reader` input node now accepts 2 new configuration arguments:

- `reduce_by`: an integer that represents the scaling factor of the input images (using this keeps the original aspect ratio of the input images)
- `resize_by`: a list containing the new dimensions of the input images

If both arguments are provided in the configuration, the `resize_by` will be used.

### Affected components
`image_reader` input node.