### PR TITLE
Keep track of data ids that resulted in a data transmission for nodes

### DIFF
--- a/juturna/components/_node.py
+++ b/juturna/components/_node.py
@@ -96,6 +96,7 @@ class Node[T_Input, T_Output]:
 
         self._destinations: dict[str, queue.Queue] = dict()
         self._origins: list = list()
+        self._last_data_source_evt_id: int | None = None
 
         self.telemetry = False
         self._telemetry_buffer = list()
@@ -328,7 +329,10 @@ class Node[T_Input, T_Output]:
             The message to be transmitted.
 
         """
-        _ = message.freeze() if isinstance(message, Message) else None
+        object.__setattr__(
+            message, '_data_source_id', self._last_data_source_evt_id
+        )
+        _ = message._freeze() if isinstance(message, Message) else None
 
         for node_name in self._destinations:
             self._destinations[node_name].put(message)
@@ -454,6 +458,7 @@ class Node[T_Input, T_Output]:
 
                 continue
 
+            self._last_data_source_evt_id = batch.id
             self.update(batch)
 
     def _source(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 import pathlib
 import shutil
+import itertools
 
 import pytest
+
+import juturna as jt
 
 
 test_pipeline_folder = './tests/running_pipelines'
@@ -26,6 +29,14 @@ def test_config():
 
     ...
 
+
+@pytest.fixture(autouse=True)
+def reset_message_counter():
+    jt.components.Message._id_gen = itertools.count()
+
+    yield
+
+    ...
 
 @pytest.fixture(autouse=True, scope='session')
 def prepare_pipe_folder(request):

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -25,6 +25,7 @@ def test_message_init():
     assert msg.payload is None
     assert msg.meta == dict()
     assert msg.timers == dict()
+    assert msg._data_source_id == None
 
 
 def test_message_init_with_params():
@@ -240,7 +241,7 @@ def test_message_serialisation_image():
 def test_message_freeze_modify_message():
     test_message = Message(creator='tester', version=10)
 
-    test_message.freeze()
+    test_message._freeze()
 
     with pytest.raises(TypeError) as context:
         test_message.creator = 'new_tester'
@@ -252,7 +253,7 @@ def test_message_freeze_modify_message():
 def test_message_freeze_delete_message_attr():
     test_message = Message(creator='tester', version=10)
 
-    test_message.freeze()
+    test_message._freeze()
 
     with pytest.raises(TypeError) as context:
         del test_message.creator
@@ -266,7 +267,7 @@ def test_message_freeze_meta():
 
     test_message.meta['first_value'] = 10
 
-    test_message.freeze()
+    test_message._freeze()
 
     with pytest.raises(TypeError) as context:
         test_message.meta['first_value'] = 20
@@ -278,7 +279,7 @@ def test_message_freeze_meta():
 def test_message_freeze_timers():
     test_message = Message(creator='tester', version=10)
 
-    test_message.freeze()
+    test_message._freeze()
 
     with pytest.raises(TypeError) as context:
         with test_message.timeit('not_allowed'):
@@ -298,7 +299,7 @@ def test_message_draft_payload():
     test_message.payload.sampling_rate = 1001
     test_message.payload.channels = 12
 
-    test_message.freeze()
+    test_message._freeze()
 
     assert isinstance(test_message.payload, AudioPayload)
     assert test_message.payload.sampling_rate == 1001
@@ -316,7 +317,7 @@ def test_message_draft_payload_object():
     test_message.payload.second_key = 'value'
     test_message.payload.third_key = False
 
-    test_message.freeze()
+    test_message._freeze()
 
     assert isinstance(test_message.payload, ObjectPayload)
     assert test_message.payload['first_key'] == 10
@@ -335,7 +336,7 @@ def test_message_draft_payload_object_attr():
     test_message.payload['second_key'] = 'value'
     test_message.payload['third_key'] = False
 
-    test_message.freeze()
+    test_message._freeze()
 
     assert isinstance(test_message.payload, ObjectPayload)
     assert test_message.payload['first_key'] == 10

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,45 @@
+import time
+
+import juturna as jt
+
+
+def test_data_source_id_properly_set(test_config):
+    p = test_config['test_pipeline_folder']
+
+    pipeline_config = {
+        'version': '0.2.0',
+        'plugins': ['./tests/test_plugins'],
+        "pipeline": {
+            'name': 'e2e_test_pipeline_generated_messages',
+            'id': 'e2e_1',
+            'folder': f'{p}/e2e_test_pipeline',
+            'nodes': [
+                {
+                    'name': 'source_1',
+                    'type': 'source',
+                    'mark': 'sequencer',
+                    'configuration': {}
+                },
+                {
+                    'name': 'sink_1',
+                    'type': 'sink',
+                    'mark': 'crasher',
+                    'configuration': {}
+                }
+            ],
+            'links': [{'from': 'source_1', 'to': 'sink_1'}]
+        }
+    }
+
+    pipeline = jt.components.Pipeline(pipeline_config)
+    pipeline.warmup()
+
+    pipeline.start()
+    time.sleep(5)
+    pipeline.stop()
+
+    out_messages = pipeline._nodes['sink_1'].messages
+
+    assert len(pipeline._nodes['sink_1'].messages) == 4
+
+    assert out_messages[0]._data_source_id == 0


### PR DESCRIPTION
### Description
In this PR, nodes and messages contribute to keep track of data ids that resulted in a transmission event. In short, messages carry the id of the message that contributed to their creation. If a node receives message 10 and transmits message 11, then message 11 will hold the id 10 indicating it was generated starting from message 10. So, a message has the `_data_source_id` field to store that information.

**PR type**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
- New private field added to base node, carrying the last message that triggered an `update` call
- New private field added to messages, carrying the id of the data that was sent to the update prior to that message generation
- Messages cannot be frozen in the node update code, but they will always be automatically frozen before being transmitted

### Affected components
- `Node` class
- `Message` class