### PR TITLE
Sanitize metadata before protobuf serialization to prevent crashes

### DIFF
--- a/juturna/remotizer/utils.py
+++ b/juturna/remotizer/utils.py
@@ -435,7 +435,7 @@ def sanitize_struct_for_proto(meta: dict[str, Any]) -> dict[str, Any]:
     if not meta:
         return {}
 
-    logger.debug(f'sanitizing metadata with {len(meta)} entries')
+    logger.info(f'sanitizing metadata with {len(meta)} entries')
     sanitized = to_primitive(dict(meta))
 
     if sanitized is None:


### PR DESCRIPTION
## Description

This PR fixes a critical bug where `message_to_proto` crashes with `ValueError: Unexpected type` when metadata contains non-primitive types (custom objects, numpy arrays, YOLO results, lambdas, file handles, etc.).

The root cause is that `google.protobuf.Struct` only supports JSON-serializable primitives: `None`, `bool`, `int`, `float`, `str`, `list`, and `dict`.

## Changes

### Added
- `to_primitive()`: Recursively converts objects to JSON-compatible primitives
  - Handles numpy types (arrays, integers, floats)
  - Converts datetime/date to ISO strings
  - Converts Decimal to float
  - Converts bytes to UTF-8 strings
  - Handles MappingProxyType (common in message.meta)
  - Explicitly rejects non-serializable types (callables, classes, file handles, locks, etc.)
  - Logs warnings for dropped non-serializable objects
  
- `sanitize_struct_for_proto()`: Wrapper function to sanitize metadata dictionaries before protobuf serialization

### Modified
- `message_to_proto()`: Now sanitizes metadata before calling `proto.meta.update()`

## Supported Conversions

| Type | Conversion |
|------|------------|
| Primitives (None, bool, int, float, str) | Pass through |
| numpy.integer, numpy.floating | Convert to Python int/float |
| numpy.ndarray | Convert to list |
| datetime, date | Convert to ISO string |
| Decimal | Convert to float |
| bytes | Decode to UTF-8 (or drop if fails) |
| MappingProxyType | Convert to dict |
| dict, list, tuple | Recursive sanitization |
| Custom objects with __dict__ | Convert __dict__ recursively |
| Classes, file handles, etc. | Drop with warning |

## Related Issues

Relates to #107 