### PR TITLE
fix: audio rtp av node output shape

### DIFF
--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -169,7 +169,7 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
                             creator=self.name,
                             version=self._abs_recv,
                             payload=AudioPayload(
-                                audio=audio_data,
+                                audio=audio_data[0],
                                 sampling_rate=self._out_rate,
                                 channels=self._out_channels,
                                 audio_format=self._resampler_format,


### PR DESCRIPTION
### Description
This PR addresses an issue with the `audio_rtp_av` node. Currently, the node returns a nested array containing the sampled audio, and this format is not consistant with other audio sources in juturna.

**PR type**
Select all the labels that apply to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
The `audio_rtp_av` node now returns a flat array.

### Affected components
`audio_rtp_av` source node.