### PR TITLE
Full ollama input in transmitted messages

### DIFF
--- a/plugins/nodes/proc/_prompter_ollama/prompter_ollama.py
+++ b/plugins/nodes/proc/_prompter_ollama/prompter_ollama.py
@@ -135,7 +135,7 @@ class PrompterOllama(Node[ObjectPayload, ObjectPayload]):
                 response_dict = dict()
 
         to_send.payload['ollama_response'] = response.model_dump()
-        to_send.payload['prompt'] = message.payload['prompt']
+        to_send.payload['source'] = message.payload
         to_send.payload['structured_response'] = response_dict
 
         self.transmit(to_send)


### PR DESCRIPTION
### Description
In this PR the ollama node is changed so that not only the input prompt is included in its reply, but the full input message.

**PR type**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
The ollama prompter node now produces output message that contain the full source payload.