### PR TITLE
Automatically stop a launched pipeline if all nodes are stopped

### DIFF
--- a/juturna/cli/commands/launch.py
+++ b/juturna/cli/commands/launch.py
@@ -87,4 +87,17 @@ def _execute(args) -> int:
         return 0
 
     while True:
-        time.sleep(60)
+        if all(
+            [
+                n['status'] == jt.names.ComponentStatus.STOPPED
+                for n in pipeline.status['nodes'].values()
+            ]
+        ):
+            print('all nodes stopped, exiting...')
+
+            pipeline.stop()
+            pipeline.destroy()
+
+            return 0
+
+        time.sleep(10)


### PR DESCRIPTION
### Description
This PR introduces an automatic exit for pipelines started from the CLI, once all its composing nodes are stopped. This allows pipelines not to run forever if all its composing nodes are not doing anything.

**PR type**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [x] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
The CLI command to launch a pipeline now checks for nodes status when launched in automatic mode.