### PR TITLE
Added plugin source node for csv feeding

### DIFF
--- a/plugins/nodes/source/_csv_data_loader/README.md
+++ b/plugins/nodes/source/_csv_data_loader/README.md
@@ -1,0 +1,7 @@
+# json_data_loader
+
+## Node type: source
+
+## Node class name: JsonDataLoader
+
+## Node name: json_data_loader

--- a/plugins/nodes/source/_csv_data_loader/config.toml
+++ b/plugins/nodes/source/_csv_data_loader/config.toml
@@ -1,0 +1,6 @@
+[arguments]
+source_file = ""
+interval = 1
+header = []
+
+[meta]

--- a/plugins/nodes/source/_csv_data_loader/csv_data_loader.py
+++ b/plugins/nodes/source/_csv_data_loader/csv_data_loader.py
@@ -1,0 +1,100 @@
+"""
+JsonDataLoader
+
+@author: Antonio Bevilacqua
+@email: abevilacqua@meetecho.com
+@created_at: 2026-03-11 16:20:39
+
+Read a csv file, transmit rows in JSON format.
+"""
+
+import csv
+
+from juturna.components import Node
+from juturna.components import Message
+
+from juturna.payloads import ObjectPayload
+from juturna.payloads import ControlSignal
+from juturna.payloads import ControlPayload
+
+
+class CsvDataLoader(Node[ObjectPayload, ObjectPayload]):
+    """Node implementation class"""
+
+    def __init__(
+        self,
+        source_file: str,
+        interval: int,
+        header: list,
+        **kwargs,
+    ):
+        """
+        Parameters
+        ----------
+        source_file : str
+            Path of the csv source file to read.
+        interval : int
+            How often data should be transmitted.
+        header : list
+            Keys of the produced object.
+        kwargs : dict
+            Supernode arguments.
+
+        """
+        super().__init__(**kwargs)
+
+        self._source_file = source_file
+        self._interval = interval
+        self._header = header
+
+        self._file = None
+        self._reader = None
+
+        self.set_source(self._generate, by=self._interval, mode='pre')
+
+    def _generate(self):
+        try:
+            return Message[ObjectPayload](
+                creator=self.name,
+                payload=ObjectPayload.from_dict(
+                    {
+                        k: v
+                        for k, v in zip(
+                            self._header, next(self._reader), strict=True
+                        )
+                    }
+                ),
+            )
+        except StopIteration:
+            return Message(
+                creator=self.name,
+                payload=ControlPayload(ControlSignal.STOP_PROPAGATE),
+            )
+
+    def warmup(self):
+        """Warmup the node"""
+        self._file = open(self._source_file)  # noqa: SIM115
+        self._reader = csv.reader(self._file)
+
+        if len(self._header) == 0:
+            self._header = next(self._reader)
+
+    def start(self):
+        """Start the node"""
+        super().start()
+
+    def stop(self):
+        """Stop the node"""
+        super().stop()
+
+        if self._file and not self._file.closed:
+            self._file.close()
+
+    def destroy(self):
+        """Destroy the node"""
+        ...
+
+    def update(self, message: Message[ObjectPayload]):
+        """Receive data from upstream, transmit data downstream"""
+        self.logger.info(f'transmitting {message}')
+        self.transmit(message)


### PR DESCRIPTION
### Description
This PR introduces a plugin node for sourcing data from a csv file. The node converts rows in a target csv file into objects, then transmits them as object payloads.

**PR type**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
New plugin node added.

### Additional context
This node streams the source csv file, so it keeps it open until the node itself is stopped.