### PR TITLE
Telemetry writer now checks for availability of size field in messages

### DIFF
--- a/juturna/components/_node.py
+++ b/juturna/components/_node.py
@@ -527,7 +527,7 @@ class Node[T_Input, T_Output]:
             message.creator,
             message.id,
             message._data_source_id,
-            message.payload.size_bytes,
+            getattr(message.payload, 'size_bytes', 0),
         )
 
         self._telemetry_buffer.append(telemetry_entry)


### PR DESCRIPTION
### Description
This PR addresses #140 and introduces a soft get of payload size field within the telemetry writer.

**PR type**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):