### PR TITLE
feat(plugins): fixed improper dict in topic history

### DIFF
--- a/plugins/nodes/proc/_summarizer_ollama/summarizer_ollama.py
+++ b/plugins/nodes/proc/_summarizer_ollama/summarizer_ollama.py
@@ -23,6 +23,8 @@ from juturna.payloads import ObjectPayload
 from juturna.payloads import Batch
 from juturna.payloads import Draft
 
+from juturna.utils.proc_utils import safe_exec
+
 
 class SummarizerOllama(Node[ObjectPayload, ObjectPayload]):
     """Node implementation class"""
@@ -123,6 +125,7 @@ class SummarizerOllama(Node[ObjectPayload, ObjectPayload]):
 
         self.logger.info(f'model {self._model_name} loaded')
 
+    @safe_exec
     def update(self, message: Message[ObjectPayload | Batch]):
         """Receive data from upstream, transmit data downstream"""
         msgs = (
@@ -197,6 +200,9 @@ class SummarizerOllama(Node[ObjectPayload, ObjectPayload]):
         self._update_history(topic, summary)
 
     def _update_history(self, topic: str, summary: str):
+        if isinstance(summary, dict):
+            summary = json.dumps(summary)
+
         msg = {'role': 'user', 'content': summary}
 
         if topic in self._topic_history:


### PR DESCRIPTION
### Description
This PR decorates the `update` method in the summarizer node with the `safe_exec` decorator, to prevent it from breaking whenever unexpected responses are returned from the model. It also addresses an issue with dictionary object being added to a topic history.

**PR type**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactoring
- [x] Performance improvement