### PR TITLE
fix(faster-whisper): reverting nvidia library version to 12

### DIFF
--- a/plugins/nodes/proc/_transcriber_whispy/requirements.txt
+++ b/plugins/nodes/proc/_transcriber_whispy/requirements.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pypi.nvidia.com
 faster-whisper==1.2.1
-nvidia-cuda-runtime
-nvidia-cublas
-nvidia-cudnn
+nvidia-cuda-runtime-cu12
+nvidia-cublas-cu12
+nvidia-cudnn-cu12


### PR DESCRIPTION
### Description
Revert transcriber_whispy deps to cu12 due to ctranslate2 constraints.

**PR type**
Select all the labels that apply to this PR.

- [X] Bug fix (non-breaking change which fixes an issue)