### PR TITLE
docs: fixed typo in virtual env code example

### DIFF
--- a/docs/source/welcome/install.rst
+++ b/docs/source/welcome/install.rst
@@ -17,6 +17,7 @@ where you can install juturna. In here, we are using the built-in `venv`
 module.
 
 .. code-block:: console
+
     $ python3 -m venv .venv
     $ source .venv/bin/activate
     (.venv) $ pip install juturna


### PR DESCRIPTION
### Description
Fixed a tpo in the documentation preventing a code block to show.

**PR type**
- [x] Documentation update