### PR TITLE
fix the audio rtp av issue on flushing

### DIFF
--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -12,12 +12,14 @@ import threading
 import pathlib
 
 import av
+import numpy as np
 
 from juturna.components import Node
 from juturna.components import Message
 
 from juturna.payloads import AudioPayload
 from juturna.components import _resource_broker as rb
+from juturna.meta import JUTURNA_THREAD_JOIN_TIMEOUT
 
 
 class AudioRtpAv(Node[AudioPayload, AudioPayload]):
@@ -28,6 +30,7 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
         'protocol_whitelist': 'file,udp,rtp',
         'buffer_size': '4096',
         'stimeout': '1500000',
+        'rw_timeout': '500000',
         'probesize': '1024',
         'analyzeduration': '0',
         'flags': 'low_delay',
@@ -44,6 +47,7 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
         out_channels: int,
         resampler_format: str,
         block_size: int,
+        flush_partial_on_error: bool,
         **kwargs,
     ):
         """
@@ -68,6 +72,9 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
             https://github.com/PyAV-Org/PyAV/blob/main/av/audio/frame.py#L16
         block_size : int
             Size of the audio block to sample, in seconds.
+        flush_partial_on_error : bool
+            Whether to flush the pending buffer when an error/close occurs.
+            The emitted chunk will be padded to expected block size with zeros
         kwargs : dict
             Supernode arguments.
 
@@ -82,16 +89,18 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
         self._out_channels = out_channels
         self._block_size = block_size
         self._resampler_format = resampler_format
-
+        self._flush_partial_on_error = flush_partial_on_error
         self._samples_per_block = int(self._out_rate * self._block_size)
         self._container = None
         self._resampler = None
-        self._fifo = None
         self._sdp_file_path = None
 
         self._t = None
         self._stop_event = threading.Event()
+
         self._abs_recv = 0
+        self._elapsed = 0.0
+        self._pending = np.empty((0,), dtype=np.float32)
 
     def configure(self):
         """Configure the node"""
@@ -108,32 +117,26 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
     def start(self):
         """Start the node"""
         self._t.start()
-
         super().start()
 
     def stop(self):
         """Stop the node"""
         self._stop_event.set()
         self._t.join()
-
         super().stop()
 
     def update(self, message: Message[AudioPayload]):
         """Receive data from upstream, transmit data downstream"""
-        message.meta['size'] = self._block_size
-
-        self.transmit(message)
+        self.logger.debug('update method not implemented for source node')
 
     def _stream_audio_blocks(self):
-        self._container = None
-
         try:
             self._container = av.open(
-                self.sdp_descriptor, options=self._OPTIONS
+                self.sdp_descriptor,
+                options=self._OPTIONS,
+                timeout=(None, JUTURNA_THREAD_JOIN_TIMEOUT),
             )
             self._stream = self._container.streams.audio[0]
-
-            self._fifo = av.audio.fifo.AudioFifo()
             self._resampler = av.AudioResampler(
                 format=self._resampler_format,
                 layout='mono' if self._out_channels == 1 else 'stereo',
@@ -146,45 +149,70 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
 
                 for raw_frame in packet.decode():
                     for frame in self._resampler.resample(raw_frame):
-                        frame.pts = None
-                        self._fifo.write(frame)
+                        yield frame.to_ndarray()[0]
 
-                        while self._fifo.samples >= self._samples_per_block:
-                            yield self._fifo.read(self._samples_per_block)
+        except OSError:
+            raise
         finally:
             if self._container:
                 self._container.close()
+                self._container = None
+
+    def _flush_pending(self, force: bool = False):
+        while len(self._pending) >= self._samples_per_block:
+            chunk = self._pending[: self._samples_per_block]
+            self._pending = self._pending[self._samples_per_block :]
+            self._emit_chunk(chunk)
+
+        if force and len(self._pending) > 0:
+            self._emit_chunk(
+                np.pad(
+                    self._pending,
+                    (0, self._samples_per_block - len(self._pending)),
+                    mode='constant',
+                )
+            )
 
     def _generate_chunks(self):
         while not self._stop_event.is_set():
             try:
-                for chunk in self._stream_audio_blocks():
+                for samples in self._stream_audio_blocks():
+                    self._pending = np.concatenate([self._pending, samples])
+                    self._flush_pending(force=False)
+
                     if self._stop_event.is_set():
                         break
-
-                    audio_data = chunk.to_ndarray()
-
-                    self.put(
-                        Message[AudioPayload](
-                            creator=self.name,
-                            version=self._abs_recv,
-                            payload=AudioPayload(
-                                audio=audio_data[0],
-                                sampling_rate=self._out_rate,
-                                channels=self._out_channels,
-                                audio_format=self._resampler_format,
-                                start=self._block_size * self._abs_recv,
-                                end=self._block_size * (self._abs_recv + 1),
-                            ),
-                        )
-                    )
-
-                    self._abs_recv += 1
-
+            except av.error.ExitError:
+                self.logger.debug(
+                    f'demux terminate while reading {self._stop_event.is_set()}'
+                )
             except OSError as e:
                 if not self._stop_event.is_set():
-                    self.logger.info(f'source unavailable ({e}), retrying...')
+                    self.logger.error(f'source unavailable ({e}), retrying...')
                     self._stop_event.wait(2.0)
+            finally:
+                self._flush_pending(force=self._flush_partial_on_error)
+                self._pending = np.empty((0,), dtype=np.float32)
+                self._elapsed = 0.0
+
+    def _emit_chunk(self, audio: np.ndarray):
+        chunk_duration = len(audio) / self._out_rate
+        message = Message[AudioPayload](
+            creator=self.name,
+            version=self._abs_recv,
+            payload=AudioPayload(
+                audio=audio,
+                sampling_rate=self._out_rate,
+                channels=self._out_channels,
+                audio_format=self._resampler_format,
+                start=self._elapsed,
+                end=self._elapsed + chunk_duration,
+            ),
+        )
+        message.meta['size'] = message.payload.end - message.payload.start
+        self._abs_recv += 1
+        self._elapsed += chunk_duration
+        self.transmit(message)
 
     @property
     def sdp_descriptor(self) -> pathlib.Path:

--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -1,8 +1,8 @@
 """
 AudioRtpAv
 
-@author: Antonio Bevilacqua
-@email: b3by.in.th3.sky@gmail.com
+@author: Antonio Bevilacqua, Paolo Saviano
+@email: b3by.in.th3.sky@gmail.com, psaviano@meetecho.com
 @created_at: 2025-12-16 21:54:39
 
 Consume RTP audio streams using PyAv.

--- a/juturna/nodes/source/_audio_rtp_av/config.toml
+++ b/juturna/nodes/source/_audio_rtp_av/config.toml
@@ -7,6 +7,6 @@ out_rate = 16000
 out_channels = 1
 resampler_format = "dblp"
 block_size = 3
-flush_partial_on_error = True
+flush_partial_on_error = true
 
 [meta]

--- a/juturna/nodes/source/_audio_rtp_av/config.toml
+++ b/juturna/nodes/source/_audio_rtp_av/config.toml
@@ -7,6 +7,6 @@ out_rate = 16000
 out_channels = 1
 resampler_format = "dblp"
 block_size = 3
-flush_partial = True
+flush_partial_on_error = True
 
 [meta]

--- a/juturna/nodes/source/_audio_rtp_av/config.toml
+++ b/juturna/nodes/source/_audio_rtp_av/config.toml
@@ -7,5 +7,6 @@ out_rate = 16000
 out_channels = 1
 resampler_format = "dblp"
 block_size = 3
+flush_partial = True
 
 [meta]

--- a/tests/test_audio_rtp_av.py
+++ b/tests/test_audio_rtp_av.py
@@ -107,11 +107,13 @@ class TestAudioRtpAvNetworkResilience:
           sender.send_tick()
           time.sleep(0.05)
 
+        print(f"received {node._abs_recv} packets on {node_params['port']} before simulating network error")
+
         start_wait = time.time()
         while node._abs_recv == 0 and (time.time() - start_wait) < 5:
           time.sleep(0.1)
 
-        assert node._abs_recv > 0, f"Node did not receive initial packets as expected, received {node._abs_recv} packets on {node_params['port']}"
+        assert node._abs_recv == 22, f"Node did not receive initial packets as expected, received {node._abs_recv} packets on {node_params['port']}"
 
         last_recv = node._abs_recv
 
@@ -121,11 +123,11 @@ class TestAudioRtpAvNetworkResilience:
         time.sleep(2.0)
 
         new_sender = RTPSender(port=node_params["port"])
-        for _ in range(10):
+        for _ in range(12):
           new_sender.send_tick()
           time.sleep(0.05)
 
-        assert node._abs_recv > last_recv, f"Node did not recover from network error as expected {node._abs_recv} packets received on {node_params['port']}"
+        assert node._abs_recv == last_recv + 22, f"Node did not recover from network error as expected {node._abs_recv} packets received on {node_params['port']}"
         new_sender.close()
 
       finally:

--- a/tests/test_audio_rtp_av.py
+++ b/tests/test_audio_rtp_av.py
@@ -1,0 +1,140 @@
+import pytest
+import socket
+import time
+import threading
+import struct
+import random
+import numpy as np
+from pathlib import Path
+
+from juturna.nodes.source._audio_rtp_av.audio_rtp_av import AudioRtpAv
+from juturna.components import Message
+from juturna.payloads import ControlPayload, ControlSignal
+
+class RTPSender:
+    def __init__(self, host="127.0.0.1", port=5005, payload_type=10):
+        self.address = (host, port)
+        self.payload_type = payload_type
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        self.rate = 8000
+        self.packet_duration = 1.0  # 1 second of audio per tick
+        self.samples_per_packet = int(self.rate * self.packet_duration)
+
+        self.sequence_number = 0
+        self.timestamp = 0
+        self.ssrc = 12345
+
+        t = np.linspace(0, self.packet_duration, self.samples_per_packet, endpoint=False)
+        audio_samples = (np.sin(2 * np.pi * 440 * t) * 32767).astype('>i2')
+        self.audio_data = audio_samples.tobytes()
+
+    def send_tick(self, simulate_network_error=False):
+        if simulate_network_error:
+            self.sock.close()
+            raise OSError("Simulated Network Unreachable")
+
+        header = struct.pack(
+            '!BBHII',
+            0x80,
+            self.payload_type,
+            self.sequence_number,
+            self.timestamp,
+            self.ssrc
+        )
+
+        self.sock.sendto(header + self.audio_data, self.address)
+
+        self.sequence_number = (self.sequence_number + 1) & 0xFFFF
+        self.timestamp += self.samples_per_packet
+
+    def close(self):
+        try:
+            self.sock.close()
+        except:
+            pass
+
+def generate_stop_message():
+    return Message(payload=ControlPayload(ControlSignal.STOP), creator="test_control", version=999)
+
+class TestAudioRtpAvNetworkResilience:
+
+    @pytest.fixture
+    def random_port(self):
+        """Genera un porto random superiore a 12000."""
+        return random.randint(12001, 65535)
+
+    @pytest.fixture
+    def node_params(self, random_port):
+        return {
+            "host": "127.0.0.1",
+            "port": random_port,
+            "payload_type": 10,
+            "encoding_clock_chan": "PCMU/8000",
+            "out_rate": 8000,
+            "out_channels": 1,
+            "resampler_format": "s16",
+            "block_size": 1,
+            "flush_partial_on_error": True,
+            "node_name": "test_node",
+            "pipe_name": "test_pipe",
+        }
+    @pytest.fixture
+    def temp_pipeline_path(self, tmp_path):
+        d = tmp_path / "pipeline_data"
+        d.mkdir()
+        return d
+
+    def test_network_error_and_recovery(self, node_params, temp_pipeline_path):
+      node = AudioRtpAv(**node_params)
+      node._OPTIONS.update({
+            'probesize': '32',
+            'analyzeduration': '0',
+            'fflags': 'nobuffer',
+            'flags': 'low_delay'
+        })
+      node.pipe_path = Path(temp_pipeline_path)
+      node.configure()
+      node.warmup()
+      node.start()
+      time.sleep(1.0)
+      sender = RTPSender(port=node_params["port"])
+
+      try:
+
+        for _ in range(12): # 12 * 0.2s = 2.4s
+          sender.send_tick()
+          time.sleep(0.05)
+
+        start_wait = time.time()
+        while node._abs_recv == 0 and (time.time() - start_wait) < 5:
+          time.sleep(0.1)
+
+        assert node._abs_recv > 0, f"Node did not receive initial packets as expected, received {node._abs_recv} packets on {node_params['port']}"
+
+        last_recv = node._abs_recv
+
+        with pytest.raises(OSError):
+            sender.send_tick(simulate_network_error=True)
+
+        time.sleep(2.0)
+
+        new_sender = RTPSender(port=node_params["port"])
+        for _ in range(10):
+          new_sender.send_tick()
+          time.sleep(0.05)
+
+        assert node._abs_recv > last_recv, f"Node did not recover from network error as expected {node._abs_recv} packets received on {node_params['port']}"
+        new_sender.close()
+
+      finally:
+        def stop_node():
+            node.put(generate_stop_message())
+            node.join()
+
+        stop_thread = threading.Thread(target=stop_node)
+        stop_thread.start()
+
+        stop_thread.join(timeout=2)
+        sender.close()


### PR DESCRIPTION
### Description
This PR fixes the AudioRtpAv node to enhance its stability and data integrity during streaming. 
The primary focus is replacing the internal PyAV FIFO with a manual NumPy-based buffering system. 
This change allows the node to handle partial audio chunks more gracefully, specifically by providing the option to flush and pad remaining data with zeros when a stream is interrupted or closed.
Additionally, this update introduces robust timeout management to prevent the node from hanging during network failures and corrects the timestamp calculation logic in the emitted payloads.

**PR type**
Select all the labels that apply to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
* **Buffering Logic**: Replaced `av.audio.fifo.AudioFifo` with a NumPy `_pending[ array to store incoming samples.
* **Partial Flush Support**: Added `flush_partial_on_error` parameter and `_flush_pending` method to ensure no data is lost upon exit; partial chunks are now padded with zeros to match the expected block size.
* **Timeout Implementation**: Added `rw_timeout` to the default options and integrated `JUTURNA_THREAD_JOIN_TIMEOUT` into the `av.open` call to ensure the node can recover from unresponsive network resources.
* **Accurate Timestamps**: Refactored the `_emit_chunk` method to calculate start and end times based on the actual number of samples processed (elapsed time) rather than simple block indices.
* **Error Handling**: Added specific catching for `av.error.ExitError` and upgraded "source unavailable" logs from INFO to ERROR level for better visibility during failures.
* **Configuration**: Updated `config.toml` to include the partial flush toggle by default

### Affected components
Built-in Node: `juturna.nodes.source._audio_rtp_av`
