### PR TITLE
restore STOP_PROPAGATION handling for backward compatibility

### DIFF
--- a/juturna/components/_node.py
+++ b/juturna/components/_node.py
@@ -513,6 +513,9 @@ class Node[T_Input, T_Output]:
 
         match message.payload.signal:
             case ControlSignal.STOP_PROPAGATE:
+                self._logger.warning(
+                    'the stop propagate signal is deprecated, use STOP instead'
+                )
                 self.transmit(message)
                 return
             case ControlSignal.STOP:

--- a/juturna/components/_node.py
+++ b/juturna/components/_node.py
@@ -512,6 +512,9 @@ class Node[T_Input, T_Output]:
             self.stop()
 
         match message.payload.signal:
+            case ControlSignal.STOP_PROPAGATE:
+                self.transmit(message)
+                return
             case ControlSignal.STOP:
                 return
             case ControlSignal.START:


### PR DESCRIPTION
### Description
This PR restores handling of the `STOP_PROPAGATION` message in node.py for backward compatibility 

**PR type**
Select all the labels that apply to this PR.

- [X] Other (please describe): ROLLBACK

### Key modifications and changes
* restoring the handling of the STOP_PROPAGATION in the node's `_control` thread.
 
### Affected components
* `juturna/components/_node.py`

### Additional context
The `STOP PROPAGATION` message may still cause issues in pipelines with fork and join paths. It’s not recommended to rely on it. If migrating to a different pattern isn’t possible, use it with caution