### PR TITLE
refactor: remove useless coupling date between nodes

### DIFF
--- a/juturna/nodes/source/_audio_file/audio_file.py
+++ b/juturna/nodes/source/_audio_file/audio_file.py
@@ -128,7 +128,6 @@ class AudioFile(Node[AudioPayload, AudioPayload]):
 
     def update(self, message: Message[AudioPayload | ControlPayload]):  # noqa: D102
         message.meta['session_id'] = self.pipe_id
-        message.meta['size'] = self._block_size
 
         self.transmit(message)
 

--- a/juturna/nodes/source/_audio_rtp/audio_rtp.py
+++ b/juturna/nodes/source/_audio_rtp/audio_rtp.py
@@ -233,7 +233,6 @@ class AudioRTP(Node[BytesPayload, AudioPayload]):
             ),
         )
 
-        to_send.meta['size'] = self._block_size
         to_send.meta['source_recv'] = self._abs_recv
 
         self.transmit(to_send)

--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -209,7 +209,6 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
                 end=self._elapsed + chunk_duration,
             ),
         )
-        message.meta['size'] = message.payload.end - message.payload.start
         self._abs_recv += 1
         self._elapsed += chunk_duration
         self.transmit(message)

--- a/plugins/nodes/proc/_vad_silero/vad_silero.py
+++ b/plugins/nodes/proc/_vad_silero/vad_silero.py
@@ -82,7 +82,6 @@ class VadSilero(Node[AudioPayload, AudioPayload]):
         waveform = [m.payload.audio for m in self._data]
         waveform = np.concatenate(waveform)
         version = self._data[-1].version
-        block_size = self._data[-1].meta['size']
 
         to_send = Message[AudioPayload](
             creator=self.name,
@@ -94,7 +93,6 @@ class VadSilero(Node[AudioPayload, AudioPayload]):
         to_send.meta = dict(message.meta)
 
         to_send.meta['silence'] = False
-        to_send.meta['size'] = block_size
         to_send.meta['sequence_number'] = version
         to_send.meta['original_audio'] = waveform
 


### PR DESCRIPTION
### Description
Removed a useless meta[`size`] from several audio nodes:
* this parameter was unused
* can be computed through AudioPayload's start/end attributes 
* causes coupling between nodes
 
**PR type**
Select all the labels that apply to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
Any read/write of `meta['size']` has been removed

### Affected components
- `juturna/nodes/source/_audio_file/audio_file.py`
- `juturna/nodes/source/_audio_rtp/audio_rtp.py`
- `plugins/nodes/proc/_vad_silero/vad_silero.py`
- `juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py`
