### PR TITLE
Explicit tensor conversion for SileroVAD node

### DIFF
--- a/plugins/nodes/proc/_vad_silero/vad_silero.py
+++ b/plugins/nodes/proc/_vad_silero/vad_silero.py
@@ -146,9 +146,9 @@ class VadSilero(Node[AudioPayload, AudioPayload]):
         wav = audio if self._device == 'cuda' else torch.from_numpy(audio)
 
         if len(speech_ts) > 0:
-            clipped_audio = silero_vad.collect_chunks(
-                tss=speech_ts, wav=wav
-            ).cpu()
+            clipped_audio = (
+                silero_vad.collect_chunks(tss=speech_ts, wav=wav).cpu().numpy()
+            )
         else:
             clipped_audio = np.ndarray(0, dtype=np.float32)
 


### PR DESCRIPTION
### Description
This PR fixes a small issue related with the extraction of clipped audio in SileroVAD, as when GPU is used, tensors are not properly reconverted into numpy arrays.

**PR type**
- [x] Bug fix (non-breaking change which fixes an issue)