### PR TITLE
Replace hardcoded pixel format strings with PixelFormat StrEnum

### DIFF
--- a/juturna/names/__init__.py
+++ b/juturna/names/__init__.py
@@ -1,11 +1,13 @@
 # noqa: D104
 from juturna.names._component_status import ComponentStatus
 from juturna.names._pipeline_status import PipelineStatus
+from juturna.names._pixel_format import PixelFormat
 from juturna.names._service_status import ServiceStatus
 
 
 __all__ = [
     'ComponentStatus',
     'PipelineStatus',
+    'PixelFormat',
     'ServiceStatus',
 ]

--- a/juturna/names/_pixel_format.py
+++ b/juturna/names/_pixel_format.py
@@ -47,11 +47,7 @@ class PixelFormat(StrEnum):
     def is_rgb(self) -> bool:
         """Return ``True`` if the format is RGB-ordered."""
         match self:
-            case (
-                PixelFormat.RGB24
-                | PixelFormat.RGBA
-                | PixelFormat.ARGB
-            ):
+            case PixelFormat.RGB24 | PixelFormat.RGBA | PixelFormat.ARGB:
                 return True
             case _:
                 return False
@@ -60,11 +56,7 @@ class PixelFormat(StrEnum):
     def is_bgr(self) -> bool:
         """Return ``True`` if the format is BGR-ordered."""
         match self:
-            case (
-                PixelFormat.BGR24
-                | PixelFormat.BGRA
-                | PixelFormat.ABGR
-            ):
+            case PixelFormat.BGR24 | PixelFormat.BGRA | PixelFormat.ABGR:
                 return True
             case _:
                 return False

--- a/juturna/names/_pixel_format.py
+++ b/juturna/names/_pixel_format.py
@@ -1,0 +1,91 @@
+from enum import StrEnum
+from enum import unique
+
+
+@unique
+class PixelFormat(StrEnum):
+    """
+    Supported pixel formats for image and video payloads.
+    - RGB / BGR (24-bit):
+      ``RGB24``, ``BGR24``
+    - RGBA (32-bit with alpha):
+      ``RGBA``, ``ARGB``, ``BGRA``, ``ABGR``
+    - YUV planar / packed:
+      ``YUV420P``, ``YUV444P``, ``YUYV422``, ``NV12``, ``NV21``
+    - Grayscale:
+      ``GRAY``, ``GRAY8``
+    - Other:
+      ``PAL8``, ``GBRP``
+    """
+
+    # RGB / BGR (24-bit)
+    RGB24 = 'rgb24'
+    BGR24 = 'bgr24'
+
+    # RGBA (32-bit with alpha)
+    RGBA = 'rgba'
+    ARGB = 'argb'
+    BGRA = 'bgra'
+    ABGR = 'abgr'
+
+    # YUV planar / packed
+    YUV420P = 'yuv420p'
+    YUV444P = 'yuv444p'
+    YUYV422 = 'yuyv422'
+    NV12 = 'nv12'
+    NV21 = 'nv21'
+
+    # Grayscale
+    GRAY = 'gray'
+    GRAY8 = 'gray8'
+
+    # Other
+    PAL8 = 'pal8'
+    GBRP = 'gbrp'
+
+    @property
+    def is_rgb(self) -> bool:
+        """Return ``True`` if the format is RGB-ordered."""
+        return self in {
+            PixelFormat.RGB24,
+            PixelFormat.RGBA,
+            PixelFormat.ARGB,
+        }
+
+    @property
+    def is_bgr(self) -> bool:
+        """Return ``True`` if the format is BGR-ordered."""
+        return self in {
+            PixelFormat.BGR24,
+            PixelFormat.BGRA,
+            PixelFormat.ABGR,
+        }
+
+    @property
+    def has_alpha(self) -> bool:
+        """Return ``True`` if the format has an alpha channel."""
+        return self in {
+            PixelFormat.RGBA,
+            PixelFormat.ARGB,
+            PixelFormat.BGRA,
+            PixelFormat.ABGR,
+        }
+
+    @property
+    def is_yuv(self) -> bool:
+        """Return ``True`` if the format is a YUV variant."""
+        return self in {
+            PixelFormat.YUV420P,
+            PixelFormat.YUV444P,
+            PixelFormat.YUYV422,
+            PixelFormat.NV12,
+            PixelFormat.NV21,
+        }
+
+    @property
+    def is_grayscale(self) -> bool:
+        """Return ``True`` if the format is grayscale."""
+        return self in {
+            PixelFormat.GRAY,
+            PixelFormat.GRAY8,
+        }

--- a/juturna/names/_pixel_format.py
+++ b/juturna/names/_pixel_format.py
@@ -46,46 +46,63 @@ class PixelFormat(StrEnum):
     @property
     def is_rgb(self) -> bool:
         """Return ``True`` if the format is RGB-ordered."""
-        return self in {
-            PixelFormat.RGB24,
-            PixelFormat.RGBA,
-            PixelFormat.ARGB,
-        }
+        match self:
+            case (
+                PixelFormat.RGB24
+                | PixelFormat.RGBA
+                | PixelFormat.ARGB
+            ):
+                return True
+            case _:
+                return False
 
     @property
     def is_bgr(self) -> bool:
         """Return ``True`` if the format is BGR-ordered."""
-        return self in {
-            PixelFormat.BGR24,
-            PixelFormat.BGRA,
-            PixelFormat.ABGR,
-        }
+        match self:
+            case (
+                PixelFormat.BGR24
+                | PixelFormat.BGRA
+                | PixelFormat.ABGR
+            ):
+                return True
+            case _:
+                return False
 
     @property
     def has_alpha(self) -> bool:
         """Return ``True`` if the format has an alpha channel."""
-        return self in {
-            PixelFormat.RGBA,
-            PixelFormat.ARGB,
-            PixelFormat.BGRA,
-            PixelFormat.ABGR,
-        }
+        match self:
+            case (
+                PixelFormat.RGBA
+                | PixelFormat.ARGB
+                | PixelFormat.BGRA
+                | PixelFormat.ABGR
+            ):
+                return True
+            case _:
+                return False
 
     @property
     def is_yuv(self) -> bool:
         """Return ``True`` if the format is a YUV variant."""
-        return self in {
-            PixelFormat.YUV420P,
-            PixelFormat.YUV444P,
-            PixelFormat.YUYV422,
-            PixelFormat.NV12,
-            PixelFormat.NV21,
-        }
+        match self:
+            case (
+                PixelFormat.YUV420P
+                | PixelFormat.YUV444P
+                | PixelFormat.YUYV422
+                | PixelFormat.NV12
+                | PixelFormat.NV21
+            ):
+                return True
+            case _:
+                return False
 
     @property
     def is_grayscale(self) -> bool:
         """Return ``True`` if the format is grayscale."""
-        return self in {
-            PixelFormat.GRAY,
-            PixelFormat.GRAY8,
-        }
+        match self:
+            case PixelFormat.GRAY | PixelFormat.GRAY8:
+                return True
+            case _:
+                return False

--- a/juturna/nodes/source/_video_file/video_file.py
+++ b/juturna/nodes/source/_video_file/video_file.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from juturna.components import Node
 from juturna.components import Message
+from juturna.names import PixelFormat
 from juturna.payloads import BytesPayload, ImagePayload
 
 
@@ -140,7 +141,7 @@ class VideoFile(Node[BytesPayload, ImagePayload]):
                     image=full_frame,
                     width=self._width,
                     height=self._height,
-                    pixel_format='rgb24',
+                    pixel_format=PixelFormat.RGB24,
                     timestamp=time.time(),
                 ),
             )

--- a/juturna/nodes/source/_video_rtp/video_rtp.py
+++ b/juturna/nodes/source/_video_rtp/video_rtp.py
@@ -10,6 +10,7 @@ from juturna.components import Message
 from juturna.components import Node
 from juturna.components import _resource_broker as rb
 
+from juturna.names import PixelFormat
 from juturna.payloads import BytesPayload, ImagePayload
 
 
@@ -140,7 +141,7 @@ class VideoRTP(Node[BytesPayload, ImagePayload]):
                     image=full_frame,
                     width=full_frame.shape[0],
                     height=full_frame.shape[1],
-                    pixel_format='rgb24',
+                    pixel_format=PixelFormat.RGB24,
                     timestamp=time.time(),
                 ),
             )

--- a/juturna/nodes/source/_video_rtp_av/video_rtp_av.py
+++ b/juturna/nodes/source/_video_rtp_av/video_rtp_av.py
@@ -16,6 +16,7 @@ import av
 from juturna.components import Node
 from juturna.components import Message
 from juturna.components import _resource_broker as rb
+from juturna.names import PixelFormat
 from juturna.payloads import BytesPayload, ImagePayload
 
 
@@ -141,7 +142,7 @@ class VideoRtpAv(Node[BytesPayload, ImagePayload]):
                     if self._stop_event.is_set():
                         break
 
-                    full_frame = frame.to_ndarray(format='rgb24')
+                    full_frame = frame.to_ndarray(format=PixelFormat.RGB24)
 
                     to_send = Message[ImagePayload](
                         creator=self.name,
@@ -150,7 +151,7 @@ class VideoRtpAv(Node[BytesPayload, ImagePayload]):
                             image=full_frame,
                             width=full_frame.shape[1],
                             height=full_frame.shape[0],
-                            pixel_format='rgb24',
+                            pixel_format=PixelFormat.RGB24,
                             timestamp=time.time(),
                         ),
                     )


### PR DESCRIPTION
@GaijinKa 

**Description**
Introduces a PixelFormat StrEnum class to replace all hardcoded pixel format strings (e.g., 'rgb24') with centralized, type-safe constants. Since PixelFormat extends StrEnum, each member compares equal to its underlying string value, making this change fully backward compatible.
Closes #95

**PR type**
[ ] Bug fix (non-breaking change which fixes an issue)
[x] New feature (non-breaking change which adds functionality)
[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
[ ] Documentation update
[x] Code refactoring
[ ] Performance improvement
[ ] Test update
[ ] Build/CI configuration change
[ ] Other (please describe):

**Key modifications and changes:** 
- Added `juturna/names/_pixel_format.py` containing the `PixelFormat` `StrEnum` with constants for common FFmpeg pixel formats (`RGB24`, `BGR24`, `RGBA`, `ARGB`, `BGRA`, `ABGR`, `YUV420P`, `YUV444P`, `YUYV422`, `NV12`, `NV21`, `GRAY`, `GRAY8`, `PAL8`, `GBRP`)
- Added helper properties on `PixelFormat`: `is_rgb`, `is_bgr`, `has_alpha`, `is_yuv`, `is_grayscale`
- Replaced all hardcoded `'rgb24'` strings with `PixelFormat.RGB24` in `VideoFile`, `VideoRTP`, and `VideoRtpAv` source nodes

 **Affected components:**
`juturna.names` (new `PixelFormat` class and updated `__init__`)