### PR TITLE
Safely decoding received packets in `audio_rtp_av`

### DIFF
--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -151,8 +151,8 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
                     for raw_frame in packet.decode():
                         for frame in self._resampler.resample(raw_frame):
                             yield frame.to_ndarray()[0]
-                except Exception:
-                    self.logger.info('malformed packet in decoder')
+                except av.error.InvalidDataError:
+                    self.logger.warn('malformed packet in decoder, discarding')
 
         except OSError:
             raise

--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -147,9 +147,12 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
                 if self._stop_event.is_set():
                     break
 
-                for raw_frame in packet.decode():
-                    for frame in self._resampler.resample(raw_frame):
-                        yield frame.to_ndarray()[0]
+                try:
+                    for raw_frame in packet.decode():
+                        for frame in self._resampler.resample(raw_frame):
+                            yield frame.to_ndarray()[0]
+                except Exception:
+                    self.logger.info('malformed packet in decoder')
 
         except OSError:
             raise


### PR DESCRIPTION
### Description
This PR adds a try-catch block to safely decode received packets in the source `audio_rtp_av` node. It thus closes #174.

**PR type**
- [x] Bug fix (non-breaking change which fixes an issue)

### Key modifications and changes
The internals of the node are essentially the same. However, exceptions are absorbed whenever a malformed packet is received and the node attempts decoding it.

### Affected components
Built-in source node `audio_rtp_av`.