### PR TITLE
fix(audio-rtp-av): respect resampler format dtype and handle multi-channel audio correctly

### DIFF
--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -164,7 +164,15 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
 
                 for raw_frame in packet.decode():
                     for frame in self._resampler.resample(raw_frame):
-                        yield frame.to_ndarray()[0]
+                        audio_block = frame.to_ndarray()
+                        if audio_block.ndim == 2:
+                            yield (
+                                audio_block.mean(axis=0)
+                                if self._out_channels == 1
+                                else audio_block.T.reshape(-1)
+                            )
+                        else:
+                            yield audio_block
 
         except OSError:
             raise

--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -21,6 +21,19 @@ from juturna.payloads import AudioPayload
 from juturna.components import _resource_broker as rb
 from juturna.meta import JUTURNA_THREAD_JOIN_TIMEOUT
 
+FORMAT_DTYPES = {
+    'dbl': np.float64,
+    'dblp': np.float64,
+    'flt': np.float32,
+    'fltp': np.float32,
+    's16': np.int16,
+    's16p': np.int16,
+    's32': np.int32,
+    's32p': np.int32,
+    'u8': np.uint8,
+    'u8p': np.uint8,
+}
+
 
 class AudioRtpAv(Node[AudioPayload, AudioPayload]):
     """Node implementation class"""
@@ -100,7 +113,9 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
 
         self._abs_recv = 0
         self._elapsed = 0.0
-        self._pending = np.empty((0,), dtype=np.float32)
+
+        self._dtype = FORMAT_DTYPES[self._resampler_format]
+        self._pending = np.empty((0,), dtype=self._dtype)
 
     def configure(self):
         """Configure the node"""
@@ -192,7 +207,7 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
                     self._stop_event.wait(2.0)
             finally:
                 self._flush_pending(force=self._flush_partial_on_error)
-                self._pending = np.empty((0,), dtype=np.float32)
+                self._pending = np.empty((0,), dtype=self._dtype)
                 self._elapsed = 0.0
 
     def _emit_chunk(self, audio: np.ndarray):

--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -163,17 +163,17 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
                     break
 
                 try:
-                  for raw_frame in packet.decode():
-                      for frame in self._resampler.resample(raw_frame):
-                          audio_block = frame.to_ndarray()
-                          if audio_block.ndim == 2:
-                              yield (
-                                  audio_block.mean(axis=0)
-                                  if self._out_channels == 1
-                                  else audio_block.T.reshape(-1)
-                              )
-                          else:
-                              yield audio_block
+                    for raw_frame in packet.decode():
+                        for frame in self._resampler.resample(raw_frame):
+                            audio_block = frame.to_ndarray()
+                            if audio_block.ndim == 2:
+                                yield (
+                                    audio_block.mean(axis=0)
+                                    if self._out_channels == 1
+                                    else audio_block.T.reshape(-1)
+                                )
+                            else:
+                                yield audio_block
 
                 except av.error.InvalidDataError:
                     self.logger.warn('malformed packet in decoder, discarding')


### PR DESCRIPTION
### Description
This PR fixes two related issues in the AudioRtpAv node:

The _pending buffer was always initialized with dtype=np.float32 regardless of the configured resampler format, causing dtype mismatches when using formats other than flt/fltp.
Audio frames decoded from multi-channel streams were yielded using [0] indexing, silently dropping all channels beyond the first instead of properly mixing or interleaving them.

### PR type
[X] Bug fix (non-breaking change which fixes an issue)

### Key modifications and changes

Added a `FORMAT_DTYPES` mapping that translates AVFormat string identifiers (e.g. s16, flt, dbl) to their corresponding NumPy dtypes.
Introduced `self._dtype` in `__init__`, derived from `self._resampler_format` via `FORMAT_DTYPES`, replacing the hardcoded `np.float32`.
`_pending` is now initialized with `self._dtype` both at construction time and after a flush in `_generate_chunks`.
Replaced the `frame.to_ndarray()[0]` one-liner in `_stream_audio_blocks` with explicit shape handling:
* 2-D arrays (channels × samples): averaged across axis 0 when the output is mono, or transposed and reshaped to an interleaved flat array when multi-channel output is expected.
* 1-D arrays: yielded as-is.

### Affected components
Built-in node: AudioRtpAv (`juturna/nodes/audio_rtp_av.py`).

Additional context
The bug with `[0]` was silent  it produced valid-looking output for mono streams, making it easy to miss in testing. 
The `dtype` mismatch would only surface at runtime when using integer or double-precision formats, typically manifesting as a NumPy casting error or silent data corruption during chunk accumulation in `_pending`.