### PR TITLE
fix(transcribers): use safe access for VAD metadata in message.meta

### DIFF
--- a/juturna/utils/proc_utils/_trx_utils.py
+++ b/juturna/utils/proc_utils/_trx_utils.py
@@ -9,7 +9,7 @@ def rescale_trx_words(words: list, buffer: list) -> list:
         start_abs = m.payload.start
         speech_offset_map = []
 
-        for segment in m.meta['speech_timestamps']:
+        for segment in m.meta.get('speech_timestamps', []):
             speech_start_abs = start_abs + segment['start_s']
             speech_end_abs = start_abs + segment['end_s']
             speech_offset_map.append(

--- a/plugins/nodes/proc/_transcriber_parakeet/transcriber_parakeet.py
+++ b/plugins/nodes/proc/_transcriber_parakeet/transcriber_parakeet.py
@@ -111,7 +111,7 @@ class TranscriberParakeet(Node[AudioPayload, ObjectPayload]):
             timers_from=message,
         )
 
-        if message.meta['silence']:
+        if message.meta.get('silence', False):
             self.logger.info('silence detected in transcriber')
             to_send.payload['transcript'] = list()
             to_send.timer(self.name, -1)
@@ -173,7 +173,7 @@ class TranscriberParakeet(Node[AudioPayload, ObjectPayload]):
             start_abs = m.payload.start
             speech_offset_map = []
 
-            for segment in m.meta['speech_timestamps']:
+            for segment in m.meta.get('speech_timestamps', []):
                 speech_start_abs = start_abs + segment['start_s']
                 speech_end_abs = start_abs + segment['end_s']
                 speech_offset_map.append(

--- a/plugins/nodes/proc/_transcriber_qwen/transcriber_qwen.py
+++ b/plugins/nodes/proc/_transcriber_qwen/transcriber_qwen.py
@@ -96,7 +96,7 @@ class TranscriberQwen(Node[AudioPayload, ObjectPayload]):
             timers_from=message,
         )
 
-        if message.meta['silence']:
+        if message.meta.get('silence', False):
             self.logger.info('silence detected, sending silence...')
             to_send.payload['transcript'] = list()
             to_send.timer(self.name, -1)

--- a/plugins/nodes/proc/_transcriber_whispy/transcriber_whispy.py
+++ b/plugins/nodes/proc/_transcriber_whispy/transcriber_whispy.py
@@ -107,7 +107,7 @@ class TranscriberWhispy(Node[AudioPayload, ObjectPayload]):
 
         to_send.meta['origin'] = origin
 
-        if message.meta['silence']:
+        if message.meta.get('silence', False):
             self.logger.info('silence detected, sending silence...')
             to_send.payload['transcript'] = list()
             to_send.timer(self.name, -1)
@@ -174,7 +174,7 @@ class TranscriberWhispy(Node[AudioPayload, ObjectPayload]):
             start_abs = m.payload.start
             speech_offset_map = []
 
-            for segment in m.meta['speech_timestamps']:
+            for segment in m.meta.get('speech_timestamps', []):
                 speech_start_abs = start_abs + segment['start_s']
                 speech_end_abs = start_abs + segment['end_s']
                 speech_offset_map.append(


### PR DESCRIPTION
@GaijinKa @lminiero 
### Description

Transcriber nodes crash with a `KeyError` when connected directly to an audio source without a VAD node in between. The cause is unsafe access to `message.meta['silence']` and `m.meta['speech_timestamps']`, which are only set by `VadSilero`. Replaced all occurrences with `.get()` and safe defaults.

Fixes #172

**PR type**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes

- Replaced `message.meta['silence']` with `message.meta.get('silence', False)` in `TranscriberWhispy`, `TranscriberQwen`, and `TranscriberParakeet`
- Replaced `m.meta['speech_timestamps']` with `m.meta.get('speech_timestamps', [])` in `TranscriberWhispy`, `TranscriberParakeet`, and `rescale_trx_words` utility

### Affected components

`plugins/nodes/proc/_transcriber_whispy`, `plugins/nodes/proc/_transcriber_qwen`, `plugins/nodes/proc/_transcriber_parakeet`, `juturna/utils/proc_utils/_trx_utils.py`

### Additional context

When no VAD is present, `silence` defaults to `False` and `speech_timestamps` defaults to `[]`. Pipelines with a VAD upstream are unaffected since the keys will still be present and used as before.