### PR TITLE
feat(plugins): added new POC transcription node using Kroko ASR

### DIFF
--- a/plugins/nodes/proc/_transcriber_kroko/README.md
+++ b/plugins/nodes/proc/_transcriber_kroko/README.md
@@ -1,0 +1,8 @@
+# transcriber_kroko
+
+## Node type: proc
+
+## Node class name: TranscriberKroko
+
+## Node name: transcriber_kroko
+

--- a/plugins/nodes/proc/_transcriber_kroko/config.toml
+++ b/plugins/nodes/proc/_transcriber_kroko/config.toml
@@ -1,0 +1,4 @@
+[arguments]
+ws = "ws://localhost:6006"
+
+[meta]

--- a/plugins/nodes/proc/_transcriber_kroko/requirements.txt
+++ b/plugins/nodes/proc/_transcriber_kroko/requirements.txt
@@ -1,0 +1,1 @@
+websocket-client

--- a/plugins/nodes/proc/_transcriber_kroko/transcriber_kroko.py
+++ b/plugins/nodes/proc/_transcriber_kroko/transcriber_kroko.py
@@ -9,8 +9,7 @@ Transcribe audio packets using kroko-onnx (WIP)
 import typing
 
 import json
-import numpy as np
-import websocket  # pip install websocket-client
+import websocket
 
 from juturna.components import Node
 from juturna.components import Message
@@ -27,6 +26,15 @@ class TranscriberKroko(Node[AudioPayload, ObjectPayload]):
         ws,
         **kwargs
     ):
+        """
+        Parameters
+        ----------
+        ws : str
+            Kroko endpoint, including port.
+        kwargs : dict
+            Superclass arguments.
+
+        """
         super().__init__(**kwargs)
 
         self.ws_uri = ws
@@ -59,7 +67,7 @@ class TranscriberKroko(Node[AudioPayload, ObjectPayload]):
             try:
                 self.ws.close()
             except Exception:
-                pass
+                return
 
     def update(self, message: Message[AudioPayload]):
         """Receive data from upstream, transmit data downstream"""
@@ -100,8 +108,6 @@ class TranscriberKroko(Node[AudioPayload, ObjectPayload]):
                 return
             except Exception as e:
                 self.log.error(f"Kroko recv error: {e}")
-                return
-            except Exception:
                 return
 
     # uncomment next_batch to design custom synchronisation policy

--- a/plugins/nodes/proc/_transcriber_kroko/transcriber_kroko.py
+++ b/plugins/nodes/proc/_transcriber_kroko/transcriber_kroko.py
@@ -1,0 +1,109 @@
+"""
+TranscriberKroko
+
+@author: Lorenzo Miniero
+@email: lorenzo@meetecho.com
+
+Transcribe audio packets using kroko-onnx (WIP)
+"""
+import typing
+
+import json
+import numpy as np
+import websocket  # pip install websocket-client
+
+from juturna.components import Node
+from juturna.components import Message
+
+from juturna.payloads import AudioPayload
+from juturna.payloads import ObjectPayload
+from juturna.payloads import Draft
+
+class TranscriberKroko(Node[AudioPayload, ObjectPayload]):
+    """Node implementation class"""
+
+    def __init__(
+        self,
+        ws,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        self.ws_uri = ws
+        self.ws = None
+
+    def configure(self):
+        """Configure the node"""
+
+    def warmup(self):
+        """Warmup the node"""
+        self.ws = websocket.create_connection(self.ws_uri)
+        self.ws.settimeout(0.001)
+
+    def set_on_config(self, prop: str, value: typing.Any):
+        """Hot-swap node properties"""
+
+    def start(self):
+        """Start the node"""
+        # after custom start code, invoke base node start
+        super().start()
+
+    def stop(self):
+        """Stop the node"""
+        # after custom stop code, invoke base node stop
+        super().stop()
+
+    def destroy(self):
+        """Destroy the node"""
+        if self.ws:
+            try:
+                self.ws.close()
+            except Exception:
+                pass
+
+    def update(self, message: Message[AudioPayload]):
+        """Receive data from upstream, transmit data downstream"""
+        self.logger.info(f'received {message.version}')
+
+        origin = message.creator
+
+        self.logger.info('transcribing audio content')
+
+        samples = message.payload.audio
+
+        try:
+            self.ws.send(
+                samples.tobytes(),
+                opcode=websocket.ABNF.OPCODE_BINARY
+            )
+        except Exception as e:
+            self.log.error(f"Kroko send error: {e}")
+            return
+
+        while True:
+            try:
+                msg = self.ws.recv()
+                if not msg:
+                    return
+                result = json.loads(msg)
+                to_send = Message[ObjectPayload](
+                    creator=self.name,
+                    version=message.version,
+                    payload=Draft(ObjectPayload),
+                    timers_from=message,
+                )
+                to_send.meta['origin'] = origin
+                to_send.payload['transcript'] = result
+                self.transmit(to_send)
+                self.logger.info(f'transmit: {to_send.version}')
+            except websocket.WebSocketTimeoutException:
+                return
+            except Exception as e:
+                self.log.error(f"Kroko recv error: {e}")
+                return
+            except Exception:
+                return
+
+    # uncomment next_batch to design custom synchronisation policy
+    # def next_batch(sources: dict[str, list[Message]]) -> dict[str, list[int]]:
+    #     ...

--- a/plugins/nodes/proc/_transcriber_kroko/transcriber_kroko.py
+++ b/plugins/nodes/proc/_transcriber_kroko/transcriber_kroko.py
@@ -6,6 +6,7 @@ TranscriberKroko
 
 Transcribe audio packets using kroko-onnx (WIP)
 """
+
 import typing
 
 import json
@@ -18,14 +19,11 @@ from juturna.payloads import AudioPayload
 from juturna.payloads import ObjectPayload
 from juturna.payloads import Draft
 
+
 class TranscriberKroko(Node[AudioPayload, ObjectPayload]):
     """Node implementation class"""
 
-    def __init__(
-        self,
-        ws,
-        **kwargs
-    ):
+    def __init__(self, ws, **kwargs):
         """
         Parameters
         ----------
@@ -80,12 +78,9 @@ class TranscriberKroko(Node[AudioPayload, ObjectPayload]):
         samples = message.payload.audio
 
         try:
-            self.ws.send(
-                samples.tobytes(),
-                opcode=websocket.ABNF.OPCODE_BINARY
-            )
+            self.ws.send(samples.tobytes(), opcode=websocket.ABNF.OPCODE_BINARY)
         except Exception as e:
-            self.log.error(f"Kroko send error: {e}")
+            self.log.error(f'Kroko send error: {e}')
             return
 
         while True:
@@ -107,7 +102,7 @@ class TranscriberKroko(Node[AudioPayload, ObjectPayload]):
             except websocket.WebSocketTimeoutException:
                 return
             except Exception as e:
-                self.log.error(f"Kroko recv error: {e}")
+                self.log.error(f'Kroko recv error: {e}')
                 return
 
     # uncomment next_batch to design custom synchronisation policy


### PR DESCRIPTION
### Description
This PR provides a new processor node to Juturna, implementing transcriptions via [Kroko ASR](https://kroko.ai/). It's meant mostly as a proof-of-concept, as I used this code to demonstrate how easy it would be to add a new node to Juturna in a [Dangerous Demos](https://www.youtube.com/watch?v=GRpMmVn2uwA&t=22912s) session during Kamailio World.

**PR type**
Select all the labels that apply to this PR.

- [X] New feature (non-breaking change which adds functionality)
- [X] Other (please describe): new plugin

### Key modifications and changes
As anticipated in the intro, this PR provides a new processor node to Juturna, implementing transcriptions via Kroko ASR. It's meant mostly as a proof-of-concept, as the code will definitely need some refactoring before it can actually be relied upon for more than a simple demo.

It leverages the WebSocket API that Kroko ASR exposes as a way to send audio samples and receive transcription data back. The implementation is currently naive, as WebSocket interaction is only performed contextually to `update()` calls: any time samples come in via `update`, they are sent to Kroko via WebSocket, after which the code tries to perform one or more WebSocket reads, until there's no more data to receive. This is supposed to ensure we get all transcription data that Kroko processed in the meanwhile, but is probably a suboptimal way to handle this, as:

1. this may delay the reception of already available transcribed data until the next `update` call, and
2. marks the same unrelated incoming message as the origin for one or more outgoing messages with transcribed data.

A queue and/or a separate thread for handling incoming data will probably be a better way to handle that.

Considering that the language. model and other settings are configured when launching the separate Kroko ASR binaries, these settings are not exposed in this node, as there would be no way to enforce them: this _may_ be possible using the SDK APIs, but I haven't investigated this yet. The only argument that can currently be passed to the node is the WebSocket address to contact (`ws://localhost:6006` by default). The node expects 16khz mono float samples, as that's what Kroko ASR requires.

This was tested using the `source/audio_rtp_av` node feeding `flt` samples, and using precompiled Kroko ASR binaries that Banafo graciously provided us with, as I had problems building the project from the [repo](https://github.com/kroko-ai/kroko-onnx) myself. While Kroko ASR requires licensing to use pro models, there are [community models](https://kroko.ai/models) that can be used for testing, and [community licenses](https://app.kroko.ai/auth/register) that allow for free limited testing, so that's what I used in my tests of the node.