### PR TITLE
fix: avoid private telemetry thread state

### DIFF
--- a/juturna/components/_telemetry_manager.py
+++ b/juturna/components/_telemetry_manager.py
@@ -29,7 +29,7 @@ class TelemetryManager:
         self._thread.start()
 
     def stop(self):
-        if self._thread is None or self._thread._is_stopped:
+        if self._thread is None or not self._thread.is_alive():
             return
 
         self._queue.put(ControlSignal.STOP)


### PR DESCRIPTION
### Description
Fixes #179 by avoiding `threading.Thread._is_stopped` in `TelemetryManager.stop()`. Python 3.13+ no longer keeps this private implementation detail stable, so stopping telemetry can crash while checking the telemetry thread.

**PR type**
Select all the labels that apply to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other (please describe):

### Key modifications and changes
- Replaced the private `_is_stopped` check with the public `Thread.is_alive()` API.
- Kept the change limited to the telemetry manager stop guard.

### Affected components
Juturna core library: `TelemetryManager`.

### Additional context
Validation:
- `git diff --check HEAD~1..HEAD`
- `rg -n _is_stopped|is_alive|test_telemetry_stop_uses_public_thread_api juturna tests`

Not run locally.