### PR TITLE
Added message id to dictionary and string representation

### DIFF
--- a/juturna/components/_message.py
+++ b/juturna/components/_message.py
@@ -108,6 +108,7 @@ class Message[T_Input]:
             'created_at': self.created_at,
             'creator': self.creator,
             'version': self.version,
+            'id': self.id,
             'payload': self.payload,
             'meta': dict(self.meta),
             'timers': dict(self.timers),

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -23,6 +23,7 @@ def test_message_init():
     assert msg.creator is None
     assert msg.version == -1
     assert msg.payload is None
+    assert msg.id == 0
     assert msg.meta == dict()
     assert msg.timers == dict()
     assert msg._data_source_id == None
@@ -142,6 +143,7 @@ def test_message_repr_dict():
         'created_at': msg.created_at,
         'creator': None,
         'version': -1,
+        'id': 0,
         'payload': None,
         'meta': {},
         'timers': {},
@@ -157,6 +159,7 @@ def test_message_to_json():
     assert 'created_at' in json_str
     assert 'creator' in json_str
     assert 'version' in json_str
+    assert 'id' in json_str
     assert 'payload' in json_str
     assert 'meta' in json_str
     assert 'timers' in json_str
@@ -172,6 +175,7 @@ def test_message_to_json_custom_encoder():
     assert 'created_at' in json_str
     assert 'creator' in json_str
     assert 'version' in json_str
+    assert 'id' in json_str
     assert 'payload' in json_str
     assert 'meta' in json_str
     assert 'timers' in json_str
@@ -181,6 +185,7 @@ def test_message_to_json_custom_encoder():
     assert 'created_at' in recoded.keys()
     assert 'creator' in recoded.keys()
     assert 'version' in recoded.keys()
+    assert 'id' in recoded.keys()
     assert 'payload' in recoded.keys()
     assert 'meta' in recoded.keys()
     assert 'timers' in recoded.keys()


### PR DESCRIPTION
### Description
With this PR, the message id is carried to the message dictionary representation. This helps keep track of the absolute message id across all pipelines, so that developers won't have to manually keep it. Considering the message id is part of the message fields, and the dictionary representation should collect all those fields, this is in a sense a bug fix too.

**PR type**

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Test update

### Key modifications and changes
The dictionary representation of a message now also includes the `id` field.

### Affected components
The `message.py` module, and its corresponding tests.