### PR TITLE
Support for custom fields in juturna logging

### DIFF
--- a/juturna/cli/commands/_juturna_service.py
+++ b/juturna/cli/commands/_juturna_service.py
@@ -1,9 +1,9 @@
 import pathlib
+import json
 import logging
+import logging.config
 
 import uvicorn
-
-import juturna as jt
 
 from fastapi import FastAPI
 
@@ -82,16 +82,13 @@ def run(
     host: str,
     port: int,
     folder: str,
-    log_level: str,
-    log_format: str,
-    log_file: str,
+    log_config: str,
 ):
-    jt.log.formatter(log_format)
-    jt.log.jt_logger().setLevel(log_level)
+    if log_config:
+        with open(log_config) as f:
+            cfg = json.load(f)
 
-    if log_file:
-        _handler = logging.FileHandler(log_file)
-        jt.log.add_handler(_handler)
+        logging.config.dictConfig(cfg)
 
     logger.info('starting juturna service...')
 

--- a/juturna/cli/commands/serve.py
+++ b/juturna/cli/commands/serve.py
@@ -9,6 +9,7 @@ Serving the Juturna manager requires Juturna to be installed with the
 `httpwrapper` dependency group.
 """
 
+from juturna.cli import _cli_utils
 from juturna.cli.commands._juturna_service import run
 
 
@@ -43,33 +44,10 @@ def setup_parser(subparsers):  # noqa: D103
     )
 
     parser.add_argument(
-        '--log-level',
+        '--log-config',
         '-l',
-        type=str,
-        default='DEBUG',
-        choices=['NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR'],
-        help='set log level during pipeline execution',
-    )
-
-    parser.add_argument(
-        '--log-format',
-        '-F',
-        type=str,
-        default='full',
-        choices=[
-            'simple',
-            'colored',
-            'full',
-            'compact',
-            'development',
-            'minimal',
-            'json',
-        ],
-        help='log format',
-    )
-
-    parser.add_argument(
-        '--log-file', '-L', type=str, help='log file destination'
+        type=_cli_utils._is_file_ok,
+        help='log configuration file',
     )
 
 
@@ -78,7 +56,5 @@ def _execute(args):
         args.host,
         args.port,
         args.folder,
-        args.log_level,
-        args.log_format,
-        args.log_file,
+        args.log_config,
     )

--- a/juturna/components/_pipeline.py
+++ b/juturna/components/_pipeline.py
@@ -9,6 +9,7 @@ from juturna.components import Node
 from juturna.components import Message
 
 from juturna.utils.log_utils import jt_logger
+from juturna.utils.log_utils import add_extra
 
 from juturna.names import ComponentStatus
 from juturna.names import PipelineStatus
@@ -42,6 +43,9 @@ class Pipeline:
         self._pipe_path = self._raw_config['pipeline']['folder']
 
         self._logger = jt_logger(self._name)
+
+        if _log_extra := self._raw_config['pipeline'].get('log_extra'):
+            add_extra(self._name, {'pipeline_id': self._name, **_log_extra})
 
         self._nodes: dict[str, Node] = dict()
         self._links: list = list()

--- a/juturna/components/_pipeline.py
+++ b/juturna/components/_pipeline.py
@@ -8,8 +8,7 @@ import typing
 from juturna.components import Node
 from juturna.components import Message
 
-from juturna.utils.log_utils import jt_logger
-from juturna.utils.log_utils import add_extra
+from juturna.utils import log_utils
 
 from juturna.names import ComponentStatus
 from juturna.names import PipelineStatus
@@ -42,10 +41,12 @@ class Pipeline:
         self._pipe_id = self._raw_config['pipeline']['id']
         self._pipe_path = self._raw_config['pipeline']['folder']
 
-        self._logger = jt_logger(self._name)
+        self._logger = log_utils.jt_logger(self._name)
 
         if _log_extra := self._raw_config['pipeline'].get('log_extra'):
-            add_extra(self._name, {'pipeline_id': self._name, **_log_extra})
+            log_utils.add_extra(
+                self._name, {'pipeline_id': self._name, **_log_extra}
+            )
 
         self._nodes: dict[str, Node] = dict()
         self._links: list = list()
@@ -328,5 +329,7 @@ class Pipeline:
         self._nodes = None
         self._status = PipelineStatus.DESTROYED
         gc.collect()
+
+        log_utils.drop_extra(self._name)
 
         self._logger.info('pipe destroyed')

--- a/juturna/utils/log_utils/__init__.py
+++ b/juturna/utils/log_utils/__init__.py
@@ -3,6 +3,24 @@ from juturna.utils.log_utils._log_helper import jt_logger
 from juturna.utils.log_utils._log_helper import formatter
 from juturna.utils.log_utils._log_helper import formatters
 from juturna.utils.log_utils._log_helper import add_handler
+from juturna.utils.log_utils._log_helper import add_formatter
+from juturna.utils.log_utils._log_helper import add_extra
+from juturna.utils.log_utils._log_helper import JuturnaPipelineFilter
+
+from juturna.utils.log_utils._formatters import JsonFormatter
+from juturna.utils.log_utils._formatters import ColoredFormatter
+from juturna.utils.log_utils._formatters import JuturnaFormatter
 
 
-__all__ = ['jt_logger', 'formatter', 'formatters', 'add_handler']
+__all__ = [
+    'jt_logger',
+    'formatter',
+    'formatters',
+    'add_handler',
+    'add_formatter',
+    'add_extra',
+    'JsonFormatter',
+    'ColoredFormatter',
+    'JuturnaFormatter',
+    'JuturnaPipelineFilter',
+]

--- a/juturna/utils/log_utils/__init__.py
+++ b/juturna/utils/log_utils/__init__.py
@@ -5,6 +5,7 @@ from juturna.utils.log_utils._log_helper import formatters
 from juturna.utils.log_utils._log_helper import add_handler
 from juturna.utils.log_utils._log_helper import add_formatter
 from juturna.utils.log_utils._log_helper import add_extra
+from juturna.utils.log_utils._log_helper import drop_extra
 from juturna.utils.log_utils._log_helper import JuturnaPipelineFilter
 
 from juturna.utils.log_utils._formatters import JsonFormatter
@@ -19,6 +20,7 @@ __all__ = [
     'add_handler',
     'add_formatter',
     'add_extra',
+    'drop_extra',
     'JsonFormatter',
     'ColoredFormatter',
     'JuturnaFormatter',

--- a/juturna/utils/log_utils/_formatters.py
+++ b/juturna/utils/log_utils/_formatters.py
@@ -53,6 +53,24 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(log_obj, default=str)
 
 
+class JuturnaFormatter(logging.Formatter):
+    def format(self, record):
+        class SafeRecordDict(dict):
+            def __getitem__(self, key):
+                if key not in self:
+                    return f'<{key}>'
+
+                return super().__getitem__(key)
+
+        orig_dict = record.__dict__
+        record.__dict__ = SafeRecordDict(orig_dict)
+
+        try:
+            return super().format(record)
+        finally:
+            record.__dict__ = orig_dict
+
+
 _FORMATTERS = {
     'simple': logging.Formatter(
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s'

--- a/juturna/utils/log_utils/_log_helper.py
+++ b/juturna/utils/log_utils/_log_helper.py
@@ -12,6 +12,7 @@ class _JuturnaLogger:
         self._root_handler.setFormatter(
             _formatters._FORMATTERS[self._root_formatter_name]
         )
+        self._root_handler.addFilter(JuturnaPipelineFilter())
         self._root_logger.addHandler(self._root_handler)
         self._root_logger.propagate = False
 
@@ -36,6 +37,28 @@ class _JuturnaLogger:
             handler.setFormatter(fmt)
 
 
+class JuturnaPipelineFilter(logging.Filter):
+    _REGISTRY = {}
+
+    @classmethod
+    def register_pipeline(cls, pipe_name: str, extras: dict):
+        cls._REGISTRY[pipe_name] = extras or dict()
+
+    def filter(self, record):
+        parts = record.name.split('.')
+
+        if len(parts) >= 2 and parts[0] == 'jt':
+            pipe_name = parts[1]
+
+            extras = self._REGISTRY.get(pipe_name, dict())
+
+            for key, value in extras.items():
+                if not hasattr(record, key):
+                    setattr(record, key, value)
+
+        return True
+
+
 _JT_LOGGER = _JuturnaLogger()
 
 
@@ -51,6 +74,10 @@ def formatter(formatter_name: str = '') -> str | None:
     return _JT_LOGGER._formatter(formatter_name)
 
 
+def add_formatter(name: str, formatter: logging.Formatter):
+    _formatters._FORMATTERS[name] = formatter
+
+
 def add_handler(
     handler: logging.Handler, formatter: str | logging.Formatter = ''
 ):
@@ -61,4 +88,9 @@ def add_handler(
     )
 
     handler.setFormatter(formatter)
+    handler.addFilter(JuturnaPipelineFilter())
     jt_logger().addHandler(handler)
+
+
+def add_extra(logger_name: str, extra: dict):
+    JuturnaPipelineFilter.register_pipeline(logger_name, extra)

--- a/juturna/utils/log_utils/_log_helper.py
+++ b/juturna/utils/log_utils/_log_helper.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from juturna.utils.log_utils import _formatters
 
@@ -38,11 +39,54 @@ class _JuturnaLogger:
 
 
 class JuturnaPipelineFilter(logging.Filter):
-    _REGISTRY = {}
+    _REGISTRY = dict()
+    _RESERVED = [
+        'args',
+        'created',
+        'exc_info',
+        'exc_text',
+        'filename',
+        'funcName',
+        'getMessage',
+        'levelname',
+        'levelno',
+        'lineno',
+        'module',
+        'msecs',
+        'msg',
+        'name',
+        'pathname',
+        'process',
+        'processName',
+        'relativeCreated',
+        'stack_info',
+        'taskName',
+        'thread',
+        'threadName',
+    ]
 
     @classmethod
     def register_pipeline(cls, pipe_name: str, extras: dict):
+        # if any(map(lambda x: x in cls._RESERVED, extras.keys())):
+        if res := [k for k in extras if k in cls._RESERVED]:
+            warnings.warn(
+                f'cannot register extras for {pipe_name}: '
+                f'extras contain reserved keys: {res}',
+                stacklevel=1,
+            )
+
+            return
+
         cls._REGISTRY[pipe_name] = extras or dict()
+
+    @classmethod
+    def unregister_pipeline(cls, pipe_name: str):
+        if pipe_name in cls._REGISTRY:
+            del cls._REGISTRY[pipe_name]
+
+    @classmethod
+    def reserved(cls) -> list:
+        return cls._RESERVED
 
     def filter(self, record):
         parts = record.name.split('.')
@@ -94,3 +138,7 @@ def add_handler(
 
 def add_extra(logger_name: str, extra: dict):
     JuturnaPipelineFilter.register_pipeline(logger_name, extra)
+
+
+def drop_extra(logger_name: str):
+    JuturnaPipelineFilter.unregister_pipeline(logger_name)


### PR DESCRIPTION
### Description
This PR introduces a number of changes to the logging facility in juturna.

#### 1. Add formatters to the juturna logger
Users can now add custom formatters without the need to create a handler. The formatter will be added to the current handler.

```python
import logging

import juturna as jt


user_fmt = logging.Formatter('%(asctime)s --> %(message)s')

jt.log.add_formatter('custom', user_fmt)
jt.log.formatter('custom')
```

```log
2026-06-16 17:20:59,360 --> node created!
2026-06-16 17:20:59,361 --> warmed up node source_1
2026-06-16 17:20:59,361 --> warmed up node sink_1
2026-06-16 17:20:59,361 --> pipe warmed up!
2026-06-16 17:20:59,369 --> node created!
2026-06-16 17:20:59,371 --> warmed up node source_1
2026-06-16 17:20:59,371 --> warmed up node sink_1
2026-06-16 17:20:59,372 --> pipe warmed up!
2026-06-16 17:21:00,372 --> this is what?
2026-06-16 17:21:00,372 --> and this?
```

#### 2. New juturna formatter
A new type of formatter was added to juturna, called `JuturnaFormatter`. In combination with a new filter called `JuturnaPipelineFilter`, this allows to add custom fields to the log records directly in the pipeline configuration file.

The juturna formatter can be used like any other formatter:

```python
import juturna as jt


usr_fmt = jt.log.JuturnaFormatter('%(asctime)s | %(message)s')

jt.log.add_formatter('custom', user_fmt)
jt.log.formatter('custom')
```

A juturna formatter accepts non-standard fields. If those fields are not available, their name will be printed in the log output:

```python
usr_fmt = jt.log.JuturnaFormatter('%(asctime)s | %(custom_field)6s | %(name)s | %(message)s')
```

Custom fields can be defined on a pipeline level, directly in the configuration file:

```json
"pipeline": {
  "name": "awesome_pipe",
  "id": "123456",
  "folder": "./",
  "log_extra": {
    "custom_field": "AWSM"
  }
}
```

```
2026-06-16 17:32:19,012 |   AWSM | jt.pipe_0.source_1 | node created!
2026-06-16 17:32:19,014 |   AWSM | jt.pipe_0 | warmed up node source_1
2026-06-16 17:32:19,014 |   AWSM | jt.pipe_0 | warmed up node sink_1
2026-06-16 17:32:19,015 |   AWSM | jt.pipe_0 | pipe warmed up!
```

#### 3. Log configuration file for juturna service
The juturna service CLI was changed so that, instead of individual parameters for the logger, it now accepts a fully fledged log configuration file. This allows to achieve the very same granularity offered by the low-level logging APIs in juturna.

```
(.venv) $ python -m juturna serve -H 0.0.0.0 -p 8888 -f run -l log_config.json
```

An example of configuration file for the logs follows:

```json
{
  "version": 1,
  "disable_existing_loggers": true,
  "formatters": {
    "standard": {
      "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
    },
    "json": {
      "()": "juturna.utils.log_utils.JsonFormatter"
    },
    "juturna": {
      "format": "%(env)s | %(name)s | %(message)s",
      "()": "juturna.utils.log_utils.JuturnaFormatter"
    }
  },
  "handlers": {
    "console": {
      "class": "logging.StreamHandler",
      "level": "DEBUG",
      "formatter": "juturna",
      "stream": "ext://sys.stdout",
      "filters": [
        "custom"
      ]
    },
    "file_stream": {
      "class": "logging.handlers.RotatingFileHandler",
      "level": "DEBUG",
      "formatter": "json",
      "filename": "/tmp/juturna_log.json",
      "maxBytes": 10485760,
      "backupCount": 20,
      "encoding": "utf8"
    },
    "service": {
      "class": "logging.StreamHandler",
      "level": "DEBUG",
      "formatter": "standard",
      "stream": "ext://sys.stdout"
    }
  },
  "filters": {
    "custom": {
      "()": "juturna.utils.log_utils.JuturnaPipelineFilter"
    }
  },
  "root": {
    "level": "NOTSET",
    "handlers": [
      "console"
    ],
    "propogate": "yes"
  },
  "loggers": {
    "jt": {
      "handlers": [
        "console",
        "file_stream"
      ]
    },
    "jt.service": {
      "handlers": ["service"]
    }
  }
}
```

#### 4. `jt.utils.log_utils` now exposes formatters and filters
The `jt.log` module now exposes some formatters and filters that are shipped with juturna, so that their classes can be linked in the log configuration files. These are:

- `juturna.utils.log_utils.ColoredFormatter`
- `juturna.utils.log_utils.JsonFormatter`
- `juturna.utils.log_utils.JuturnaFormatter`
- `juturna.utils.log_utils.JuturnaPipelineFilter`

**PR type**
Select all the labels that apply to this PR.

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
