### PR TITLE
feat: added dev mode to juturna service to enable local development

### DIFF
--- a/juturna/cli/commands/_juturna_service.py
+++ b/juturna/cli/commands/_juturna_service.py
@@ -6,6 +6,7 @@ import logging.config
 import uvicorn
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from juturna.components._pipeline_manager import PipelineManager
 from juturna.cli.commands.models.api import PipelineConfig
@@ -18,9 +19,19 @@ from juturna.cli.commands.exceptions import (
 app = FastAPI()
 logger = logging.getLogger('jt.service')
 
-##register exception handlers
+# register exception handlers
 register_pipeline_exception_handlers(app)
 register_generic_exception_handler(app, logger)
+
+
+def enable_cross_origins(app: FastAPI):
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=['*'],
+        allow_credentials=True,
+        allow_methods=['*'],
+        allow_headers=['*'],
+    )
 
 
 @app.get('/pipelines')
@@ -78,12 +89,7 @@ def pipeline_status(pipeline_id: str):
     return status
 
 
-def run(
-    host: str,
-    port: int,
-    folder: str,
-    log_config: str,
-):
+def run(host: str, port: int, folder: str, log_config: str, dev: bool):
     if log_config:
         with open(log_config) as f:
             cfg = json.load(f)
@@ -91,6 +97,11 @@ def run(
         logging.config.dictConfig(cfg)
 
     logger.info('starting juturna service...')
+
+    if dev:
+        enable_cross_origins(app)
+
+        logger.info('development mode enabled')
 
     try:
         pathlib.Path(folder).mkdir(parents=True)

--- a/juturna/cli/commands/serve.py
+++ b/juturna/cli/commands/serve.py
@@ -50,11 +50,13 @@ def setup_parser(subparsers):  # noqa: D103
         help='log configuration file',
     )
 
+    parser.add_argument(
+        '--dev',
+        '-d',
+        action='store_true',
+        help='run service in development mode',
+    )
+
 
 def _execute(args):
-    run(
-        args.host,
-        args.port,
-        args.folder,
-        args.log_config,
-    )
+    run(args.host, args.port, args.folder, args.log_config, args.dev)


### PR DESCRIPTION
### Description
This PR adds a development mode for the juturna service. Development mode enables CORS requests so that the service can be tested with local clients. To enable it, pass the `--dev/-d` flag to the `serve` command.

**PR type**

- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring

### Key modifications and changes
The `serve` command now accepts `--dev/-d` option to run in development mode.

### Affected components
Juturna `serve` cli command.