### PR TITLE
fix(notifier_http): keep the pipe_id reference alive after the parsing

### DIFF
--- a/juturna/nodes/sink/_notifier_http/notifier_http.py
+++ b/juturna/nodes/sink/_notifier_http/notifier_http.py
@@ -76,8 +76,8 @@ class NotifierHTTP(Node[ObjectPayload, None]):
             payload=message.payload,
         )
 
-        to_send.meta['session_id'] = self.pipe_id
-        to_send = NotifierHTTP._CNT_CB[self._content_type](message)
+        to_send.meta['pipe_id'] = self.pipe_id
+        to_send = NotifierHTTP._CNT_CB[self._content_type](to_send)
 
         t = threading.Thread(
             name=f'{self.name}_thread',


### PR DESCRIPTION
### Description
The `http_notifier` sink node now preserves the reference to the `pipe_id` (aka `session_id`).

Moreover, the naming `session_id` into the `meta` has been replaced with the more meaningful `pipe_id`.
I do not consider this change breaking cause the bug made the naming not relevant.

**PR type**
- [X] Bug fix (non-breaking change which fixes an issue)

### Key modifications and changes
* `sink/_http_notifier/http_notifier.py`: now serializes the enriched version of the message. 

### Affected components
* [builtin: sink http_notifier] 

### Additional Information
Closes #188 