### PR TITLE
fix(sources_rtp_av): expose configuration and add requested flush

### DIFF
--- a/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
+++ b/juturna/nodes/source/_audio_rtp_av/audio_rtp_av.py
@@ -117,6 +117,15 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
         self._dtype = FORMAT_DTYPES[self._resampler_format]
         self._pending = np.empty((0,), dtype=self._dtype)
 
+    @Node.configuration.getter
+    def configuration(self) -> dict:  # noqa: D102
+        return {
+            'name': self.name,
+            'session_id': self.pipe_id,
+            'host': self._host,
+            'port': self._port,
+        }
+
     def configure(self):
         """Configure the node"""
         if self._port == 0:
@@ -177,6 +186,21 @@ class AudioRtpAv(Node[AudioPayload, AudioPayload]):
 
                 except av.error.InvalidDataError:
                     self.logger.warn('malformed packet in decoder, discarding')
+
+            try:
+                for frame in self._resampler.resample(None):
+                    audio_block = frame.to_ndarray()
+                    if audio_block.ndim == 2:
+                        yield (
+                            audio_block.mean(axis=0)
+                            if self._out_channels == 1
+                            else audio_block.T.reshape(-1)
+                        )
+                    else:
+                        yield audio_block
+
+            except av.error.EOFError:
+                pass
 
         except OSError:
             raise

--- a/juturna/nodes/source/_video_rtp_av/video_rtp_av.py
+++ b/juturna/nodes/source/_video_rtp_av/video_rtp_av.py
@@ -78,6 +78,15 @@ class VideoRtpAv(Node[BytesPayload, ImagePayload]):
         self._t = None
         self._stop_event = threading.Event()
 
+    @Node.configuration.getter
+    def configuration(self) -> dict:  # noqa: D102
+        return {
+            'name': self.name,
+            'session_id': self.pipe_id,
+            'host': self._rec_host,
+            'port': self._rec_port,
+        }
+
     def configure(self):
         """Configure the node"""
         if self._rec_port == 'auto':


### PR DESCRIPTION
### Description
A few minor changes on two builtin sources, to expose configuration - mainly selected ephemereal ports - during the deploy. 
Furhtermore, the `audio_rtp_av`, must flushes the resampler through a `resample(null)` on terminating

**PR type**
Select all the labels that apply to this PR.

- [X] Bug fix (non-breaking change which fixes an issue)

### Key modifications and changes
- the `audio_rtp_av` and the `video_rtp_av` now expose their configuration
- the `audio_rtp_av` flushes the resampler, as requested by documentation

### Affected components
Two builtin nodes - `audio_rtp_av` and `video_rtp_av`