### PR TITLE
feat: added telemetry endpoint to the juturna service

### DIFF
--- a/juturna/cli/commands/_juturna_service.py
+++ b/juturna/cli/commands/_juturna_service.py
@@ -89,6 +89,13 @@ def pipeline_status(pipeline_id: str):
     return status
 
 
+@app.get('/pipelines/{pipeline_id}/telemetry')
+def pipeline_telemetry(pipeline_id: str):
+    telemetry_data = PipelineManager().pipeline_telemetry(pipeline_id)
+
+    return {'pipeline': pipeline_id, 'telemetry': telemetry_data}
+
+
 def run(host: str, port: int, folder: str, log_config: str, dev: bool):
     if log_config:
         with open(log_config) as f:

--- a/juturna/cli/commands/exceptions/__init__.py
+++ b/juturna/cli/commands/exceptions/__init__.py
@@ -5,6 +5,7 @@ from ._pipeline_exceptions import (
     NotReadyException,
     AlreadyRunningException,
     NotRunningException,
+    TelemetryNotEnabledException,
 )
 
 from ._handlers_provider import (
@@ -18,6 +19,7 @@ __all__ = [
     'NotReadyException',
     'AlreadyRunningException',
     'NotRunningException',
+    'TelemetryNotEnabledException',
     'register_pipeline_exception_handlers',
     'register_generic_exception_handler',
 ]

--- a/juturna/cli/commands/exceptions/_handlers_provider.py
+++ b/juturna/cli/commands/exceptions/_handlers_provider.py
@@ -8,6 +8,7 @@ from juturna.cli.commands.exceptions import (
     AlreadyRunningException,
     NotReadyException,
     NotRunningException,
+    TelemetryNotEnabledException,
 )
 
 
@@ -63,6 +64,17 @@ def _not_running_handler(
     )
 
 
+def _telemetry_not_enabled_handler(
+    request: Request, exception: TelemetryNotEnabledException
+) -> JSONResponse:
+    _m = f'pipeline {exception.pipeline_id} does not have telemetry enabled'
+
+    return JSONResponse(
+        status_code=409,
+        content={'message': _m},
+    )
+
+
 def _make_generic_exception_handler(logger: Logger):
     def _generic_exception_handler(
         request: Request, exception: Exception
@@ -85,6 +97,7 @@ def register_pipeline_exception_handlers(app: FastAPI) -> None:
         - AlreadyRunningException
         - NotReadyException
         - NotRunningException
+        - TelemetryNotEnabledException
 
     Args:
         app (FastAPI): Fastapi instance to apply handlers to
@@ -96,12 +109,12 @@ def register_pipeline_exception_handlers(app: FastAPI) -> None:
     app.add_exception_handler(
         AlreadyWarmedupException, _already_warmedup_handler
     )
-
     app.add_exception_handler(AlreadyRunningException, _already_running_handler)
-
     app.add_exception_handler(NotReadyException, _not_ready_handler)
-
     app.add_exception_handler(NotRunningException, _not_running_handler)
+    app.add_exception_handler(
+        TelemetryNotEnabledException, _telemetry_not_enabled_handler
+    )
 
 
 def register_generic_exception_handler(app: FastAPI, logger: Logger) -> None:

--- a/juturna/cli/commands/exceptions/_pipeline_exceptions.py
+++ b/juturna/cli/commands/exceptions/_pipeline_exceptions.py
@@ -32,3 +32,7 @@ class AlreadyRunningException(BasePipelineException):
 
 class NotRunningException(BasePipelineException):
     pass
+
+
+class TelemetryNotEnabledException(BasePipelineException):
+    pass

--- a/juturna/components/_pipeline_manager.py
+++ b/juturna/components/_pipeline_manager.py
@@ -15,6 +15,7 @@ from juturna.cli.commands.exceptions import (
     AlreadyRunningException,
     NotReadyException,
     NotRunningException,
+    TelemetryNotEnabledException,
 )
 from juturna.names import PipelineStatus
 
@@ -146,6 +147,18 @@ class PipelineManager:
         logger.info(self._pipelines[pipeline_id].status)
 
         return self._pipelines[pipeline_id].status
+
+    def pipeline_telemetry(self, pipeline_id: str):
+        if pipeline_id not in self._pipelines:
+            raise InvalidPipelineIdException(pipeline_id)
+
+        if not self._pipelines[pipeline_id]._telemetry:
+            raise TelemetryNotEnabledException(pipeline_id)
+
+        with open(self._pipelines[pipeline_id]._telemetry_file) as f:
+            telemetry_data = f.read()
+
+        return telemetry_data
 
     def pipeline_list(self) -> dict:
         return {


### PR DESCRIPTION
### Description
This PR adds a new endpoint to the juturna service, so that telemetry data for sessions with enabled telemetry can be downloaded.

**PR type**
- [x] New feature (non-breaking change which adds functionality)

### Key modifications and changes
The juturna endpoint now exposes a new endpoint, that can be queried like so:

```
GET /pipelines/<remote_pipe_id>/telemetry
```

This returns the raw content of the telemetry file for that pipeline.

### Affected components
The remote service

### Additional context
In the future, should this implementation show significant overhead caused by repeated requests, a different approach could be implemented, such as pagination or streaming.