### PR TITLE
Feat/transport layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tests/running_pipelines/
 remote_pipes/
+design/
 .idea/
 .vscode/
 

--- a/juturna/components/_buffer.py
+++ b/juturna/components/_buffer.py
@@ -1,6 +1,4 @@
 import typing
-import threading
-import queue
 
 from collections.abc import Callable
 
@@ -10,15 +8,28 @@ from juturna.utils.log_utils import jt_logger
 from juturna.payloads import Batch
 from juturna.meta import JUTURNA_MAX_QUEUE_SIZE
 
+from juturna.transport import Empty
+from juturna.transport import ThreadingTransport
+from juturna.transport import TransportBackend
+
 
 class Buffer:
-    def __init__(self, creator: str, synchroniser: Callable | None = None):
+    def __init__(
+        self,
+        creator: str,
+        synchroniser: Callable | None = None,
+        transport: TransportBackend | None = None,
+    ):
+        self._transport: TransportBackend = transport or ThreadingTransport()
+
         self._data: dict[str, list[Message]] = dict()
-        self._data_lock = threading.Lock()
+        self._data_lock = self._transport.new_lock()
         self._synchroniser: Callable = synchroniser
 
         # out queue can be built based on the synchronisation policy
-        self._out_queue = queue.Queue(maxsize=JUTURNA_MAX_QUEUE_SIZE)
+        self._out_queue = self._transport.new_queue(
+            maxsize=JUTURNA_MAX_QUEUE_SIZE
+        )
 
         self._creator = creator
         self._logger = jt_logger(creator)
@@ -81,7 +92,7 @@ class Buffer:
             while not self._out_queue.empty():
                 try:
                     self._out_queue.get_nowait()
-                except queue.Empty:
+                except Empty:
                     break
 
             self._logger.debug('buffer flushed')

--- a/juturna/components/_node.py
+++ b/juturna/components/_node.py
@@ -1,8 +1,6 @@
 import pathlib
 import inspect
 import string
-import threading
-import queue
 import time
 
 from collections.abc import Callable
@@ -25,6 +23,11 @@ from juturna.components._state import State
 from juturna.components._telemetry_manager import TelemetryManager
 from juturna.components._synchronisers import _SYNCHRONISERS
 
+from juturna.transport import Empty
+from juturna.transport import ThreadingTransport
+from juturna.transport import TransportBackend
+from juturna.transport import WorkerHandle
+
 
 class Node[T_Input, T_Output]:
     """
@@ -38,6 +41,7 @@ class Node[T_Input, T_Output]:
         node_name: str = '',
         pipe_name: str = '',
         synchroniser: Callable | None = None,
+        transport: TransportBackend | None = None,
     ):
         """
         Parameters
@@ -48,6 +52,9 @@ class Node[T_Input, T_Output]:
             The name of the pipe this node belongs to.
         synchroniser : Callable
             Management options for multi-input nodes.
+        transport : TransportBackend
+            The concurrency backend used to run and synchronise the node's
+            internal workers. Defaults to a thread-based backend.
 
         """
         self.name = node_name
@@ -68,24 +75,28 @@ class Node[T_Input, T_Output]:
         self._status: ComponentStatus | None = None
         self._state: State | None = None
 
-        self._queue = queue.Queue(maxsize=JUTURNA_MAX_QUEUE_SIZE)
-        self._worker_thread: threading.Thread | None = None
-        self._source_thread: threading.Thread | None = None
-        self._update_thread: threading.Thread | None = None
+        self._transport: TransportBackend = transport or ThreadingTransport()
 
-        self._stop_worker_event = threading.Event()
-        self._stop_source_event = threading.Event()
-        self._stop_update_event = threading.Event()
+        self._queue = self._transport.new_queue(maxsize=JUTURNA_MAX_QUEUE_SIZE)
+        self._worker_thread: WorkerHandle | None = None
+        self._source_thread: WorkerHandle | None = None
+        self._update_thread: WorkerHandle | None = None
 
-        self._draining = threading.Event()
+        self._stop_worker_event = self._transport.new_signal()
+        self._stop_source_event = self._transport.new_signal()
+        self._stop_update_event = self._transport.new_signal()
+
+        self._draining = self._transport.new_signal()
 
         self._pending_updates = 0
-        self._pending_condition = threading.Condition()
+        self._pending_condition = self._transport.new_condition()
 
         self._suspended = False
         self._auto_dump = False
 
-        self._buffer = Buffer(_logger_name, self.synchroniser)
+        self._buffer = Buffer(
+            _logger_name, self.synchroniser, transport=self._transport
+        )
 
         self._source_f: Callable | None = None
         self._source_sleep = -1
@@ -300,10 +311,9 @@ class Node[T_Input, T_Output]:
         """
         self._draining.clear()
         if self._worker_thread is None:
-            self._worker_thread = threading.Thread(
-                name=f'_worker_{self.name}',
+            self._worker_thread = self._transport.spawn(
                 target=self._worker,
-                args=(),
+                name=f'_worker_{self.name}',
                 daemon=True,
             )
 
@@ -311,10 +321,9 @@ class Node[T_Input, T_Output]:
             self._status = ComponentStatus.RUNNING
 
         if self._update_thread is None:
-            self._update_thread = threading.Thread(
-                name=f'_update_{self.name}',
+            self._update_thread = self._transport.spawn(
                 target=self._update,
-                args=(),
+                name=f'_update_{self.name}',
                 daemon=True,
             )
 
@@ -324,10 +333,9 @@ class Node[T_Input, T_Output]:
             return
 
         if self._source_thread is None:
-            self._source_thread = threading.Thread(
-                name=f'_source_{self.name}',
+            self._source_thread = self._transport.spawn(
                 target=self._source,
-                args=(),
+                name=f'_source_{self.name}',
                 daemon=True,
             )
 
@@ -366,13 +374,16 @@ class Node[T_Input, T_Output]:
         with self._pending_condition:
             self._pending_condition.wait_for(lambda: self._pending_updates == 0)
 
-        current_thread = threading.current_thread()
         for _t in [
             self._source_thread,
             self._worker_thread,
             self._update_thread,
         ]:
-            if _t is not None and _t.is_alive() and _t is not current_thread:
+            if (
+                _t is not None
+                and _t.is_alive()
+                and not self._transport.is_current(_t)
+            ):
                 _t.join(timeout=JUTURNA_THREAD_JOIN_TIMEOUT)
 
     def configure(self): ...
@@ -386,8 +397,10 @@ class Node[T_Input, T_Output]:
     def destroy(self): ...
 
     def _handle_control(self, message: Message):
-        _control_thread = threading.Thread(
-            target=self._control, args=(message,), daemon=True
+        _control_thread = self._transport.spawn(
+            target=lambda: self._control(message),
+            name=f'_control_{self.name}',
+            daemon=True,
         )
         _control_thread.start()
 
@@ -395,7 +408,7 @@ class Node[T_Input, T_Output]:
         while not self._stop_worker_event.is_set():
             try:
                 message = self._queue.get(timeout=JUTURNA_THREAD_JOIN_TIMEOUT)
-            except queue.Empty:
+            except Empty:
                 continue
 
             if self._suspended and not isinstance(
@@ -413,7 +426,7 @@ class Node[T_Input, T_Output]:
         while not self._stop_update_event.is_set():
             try:
                 batch = self._buffer.get(timeout=JUTURNA_THREAD_JOIN_TIMEOUT)
-            except queue.Empty:
+            except Empty:
                 continue
 
             if isinstance(batch, Message) and isinstance(

--- a/juturna/components/_node_builder/_builder.py
+++ b/juturna/components/_node_builder/_builder.py
@@ -1,8 +1,15 @@
 from juturna.components._node_builder import _builder_internal
 from juturna.components._node_builder import _builder_external
 
+from juturna.transport import TransportBackend
 
-def _get_node(node: dict, pipe_name: str, plugin_dirs: list = None):
+
+def _get_node(
+    node: dict,
+    pipe_name: str,
+    plugin_dirs: list = None,
+    transport: TransportBackend | None = None,
+):
     """
     Build a concrete node
     The current building system instantiates both local and external nodes. The
@@ -13,7 +20,12 @@ def _get_node(node: dict, pipe_name: str, plugin_dirs: list = None):
     """
     if node.get('mark'):
         return _builder_internal.build_component(
-            node, plugin_dirs=plugin_dirs, pipe_name=pipe_name
+            node,
+            plugin_dirs=plugin_dirs,
+            pipe_name=pipe_name,
+            transport=transport,
         )
 
-    return _builder_external.build_node(node, pipe_name=pipe_name)
+    return _builder_external.build_node(
+        node, pipe_name=pipe_name, transport=transport
+    )

--- a/juturna/components/_node_builder/_builder_external.py
+++ b/juturna/components/_node_builder/_builder_external.py
@@ -8,6 +8,7 @@ from juturna.meta._constants import JUTURNA_ENV_VAR_PREFIX
 from juturna.components._synchronisers import _SYNCHRONISERS
 from juturna.components._node_builder._utils import _resolve_env_var
 from juturna.components._node_builder._utils import _update_local_with_remote
+from juturna.transport import TransportBackend
 
 
 _JT_BUILTIN_PREFIX = 'juturna.nodes'
@@ -16,7 +17,9 @@ _JT_EXTENSION_PREFIX = 'juturna'
 _logger = jt_logger('builder')
 
 
-def build_node(node: dict, pipe_name: str):
+def build_node(
+    node: dict, pipe_name: str, transport: TransportBackend | None = None
+):
     node_full_path = node['type']
     node_configuration = node['configuration']
     node_sync = node.get('sync')
@@ -52,6 +55,7 @@ def build_node(node: dict, pipe_name: str):
             'node_name': node['name'],
             'pipe_name': pipe_name,
             'synchroniser': synchroniser,
+            'transport': transport,
         },
     )
 

--- a/juturna/components/_node_builder/_builder_internal.py
+++ b/juturna/components/_node_builder/_builder_internal.py
@@ -11,12 +11,18 @@ from juturna.components._node_builder._utils import _update_local_with_remote
 from juturna.components._synchronisers import _SYNCHRONISERS
 
 from juturna.meta._constants import JUTURNA_ENV_VAR_PREFIX
+from juturna.transport import TransportBackend
 
 
 _logger = jt_logger('builder')
 
 
-def build_component(node: dict, plugin_dirs: list, pipe_name: str):
+def build_component(
+    node: dict,
+    plugin_dirs: list,
+    pipe_name: str,
+    transport: TransportBackend | None = None,
+):
     node_name = node['name']
     node_type = node['type']
     node_mark = node['mark']
@@ -69,6 +75,7 @@ def build_component(node: dict, plugin_dirs: list, pipe_name: str):
             'node_name': node_name,
             'pipe_name': pipe_name,
             'synchroniser': synchroniser,
+            'transport': transport,
         },
     )
 

--- a/juturna/components/_pipeline.py
+++ b/juturna/components/_pipeline.py
@@ -20,6 +20,9 @@ from juturna.components._state import State
 from juturna.components._node_builder import _builder
 from juturna.components._telemetry_manager import TelemetryManager
 
+from juturna.transport import TransportBackend
+from juturna.transport import get_transport
+
 
 class Pipeline:
     """
@@ -53,6 +56,10 @@ class Pipeline:
         self._links: list = list()
         self._dag: DAG = DAG()
         self._node_state_store = dict()
+
+        self._transport: TransportBackend = get_transport(
+            self._raw_config['pipeline'].get('transport')
+        )
 
         self._telemetry_manager: TelemetryManager | None = None
         self._telemetry = False
@@ -165,6 +172,7 @@ class Pipeline:
                 node,
                 pipe_name=self.name,
                 plugin_dirs=self._raw_config.get('plugins', list()),
+                transport=self._transport,
             )
 
             _node.pipe_id = copy.deepcopy(self._pipe_id)

--- a/juturna/transport/__init__.py
+++ b/juturna/transport/__init__.py
@@ -1,0 +1,23 @@
+# noqa: D104
+from juturna.transport._base import Condition
+from juturna.transport._base import Empty
+from juturna.transport._base import Lock
+from juturna.transport._base import Queue
+from juturna.transport._base import Signal
+from juturna.transport._base import TransportBackend
+from juturna.transport._base import WorkerHandle
+from juturna.transport._threading import ThreadingTransport
+from juturna.transport._registry import get_transport
+
+
+__all__ = [
+    'Condition',
+    'Empty',
+    'Lock',
+    'Queue',
+    'Signal',
+    'ThreadingTransport',
+    'TransportBackend',
+    'WorkerHandle',
+    'get_transport',
+]

--- a/juturna/transport/_base.py
+++ b/juturna/transport/_base.py
@@ -1,0 +1,83 @@
+from collections.abc import Callable
+from typing import Any
+from typing import Protocol
+
+
+class Empty(Exception):
+    """Raised by Queue.get() when no item is available within the timeout."""
+
+
+class Queue(Protocol):
+    """A FIFO channel used to move messages between nodes and workers."""
+
+    def put(self, item: Any) -> None: ...
+
+    def get(self, timeout: float | None = None) -> Any: ...
+
+    def get_nowait(self) -> Any: ...
+
+    def empty(self) -> bool: ...
+
+
+class Signal(Protocol):
+    """A boolean flag shared across workers, used to signal stop conditions."""
+
+    def set(self) -> None: ...
+
+    def clear(self) -> None: ...
+
+    def is_set(self) -> bool: ...
+
+
+class Lock(Protocol):
+    """A mutual exclusion primitive, used as a context manager."""
+
+    def __enter__(self) -> None: ...
+
+    def __exit__(self, *args) -> None: ...
+
+
+class Condition(Protocol):
+    """A lock with wait/notify semantics, used to track pending work."""
+
+    def __enter__(self) -> None: ...
+
+    def __exit__(self, *args) -> None: ...
+
+    def wait_for(self, predicate: Callable[[], bool]) -> None: ...
+
+    def notify_all(self) -> None: ...
+
+
+class WorkerHandle(Protocol):
+    """A handle to a unit of concurrent execution spawned by a backend."""
+
+    def start(self) -> None: ...
+
+    def join(self, timeout: float | None = None) -> None: ...
+
+    def is_alive(self) -> bool: ...
+
+
+class TransportBackend(Protocol):
+    """
+    Factory of concurrency primitives used by nodes and buffers.
+
+    An implementation decides how messages are moved and how workers are
+    executed (e.g. real OS threads, or a cooperative scheduler); nodes and
+    buffers only depend on this interface, never on the concrete primitives.
+    """
+
+    def new_queue(self, maxsize: int = 0) -> Queue: ...
+
+    def new_signal(self) -> Signal: ...
+
+    def new_lock(self) -> Lock: ...
+
+    def new_condition(self) -> Condition: ...
+
+    def spawn(
+        self, target: Callable[[], None], name: str, daemon: bool = True
+    ) -> WorkerHandle: ...
+
+    def is_current(self, handle: WorkerHandle) -> bool: ...

--- a/juturna/transport/_registry.py
+++ b/juturna/transport/_registry.py
@@ -1,0 +1,41 @@
+from juturna.transport._base import TransportBackend
+from juturna.transport._threading import ThreadingTransport
+
+
+_TRANSPORTS: dict[str, type[TransportBackend]] = {
+    'threading': ThreadingTransport,
+}
+
+_DEFAULT_TRANSPORT = 'threading'
+
+
+def get_transport(name: str | None = None) -> TransportBackend:
+    """
+    Resolve a transport backend by name.
+
+    Parameters
+    ----------
+    name : str | None
+        The name of the transport backend, as registered in `_TRANSPORTS`.
+        Defaults to the threading backend if not provided.
+
+    Returns
+    -------
+    TransportBackend
+        A new instance of the requested backend.
+
+    Raises
+    ------
+    ValueError
+        If `name` does not match any registered backend.
+
+    """
+    name = name or _DEFAULT_TRANSPORT
+
+    if name not in _TRANSPORTS:
+        raise ValueError(
+            f'unknown transport backend: {name!r}, '
+            f'available: {list(_TRANSPORTS)}'
+        )
+
+    return _TRANSPORTS[name]()

--- a/juturna/transport/_threading.py
+++ b/juturna/transport/_threading.py
@@ -1,0 +1,136 @@
+import threading
+import queue
+
+from collections.abc import Callable
+from typing import Any
+
+from juturna.transport._base import Empty
+from juturna.transport._base import WorkerHandle
+
+
+class _ThreadQueue:
+    """Queue primitive backed by queue.Queue."""
+
+    def __init__(self, maxsize: int = 0):
+        self._queue = queue.Queue(maxsize=maxsize)
+
+    def put(self, item: Any) -> None:
+        self._queue.put(item)
+
+    def get(self, timeout: float | None = None) -> Any:
+        try:
+            return self._queue.get(timeout=timeout)
+        except queue.Empty as exc:
+            raise Empty from exc
+
+    def get_nowait(self) -> Any:
+        try:
+            return self._queue.get_nowait()
+        except queue.Empty as exc:
+            raise Empty from exc
+
+    def empty(self) -> bool:
+        return self._queue.empty()
+
+
+class _ThreadSignal:
+    """Signal primitive backed by threading.Event."""
+
+    def __init__(self):
+        self._event = threading.Event()
+
+    def set(self) -> None:
+        self._event.set()
+
+    def clear(self) -> None:
+        self._event.clear()
+
+    def is_set(self) -> bool:
+        return self._event.is_set()
+
+
+class _ThreadLock:
+    """Lock primitive backed by threading.Lock."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+
+    def __enter__(self) -> None:
+        self._lock.acquire()
+
+    def __exit__(self, *args) -> None:
+        self._lock.release()
+
+
+class _ThreadCondition:
+    """Condition primitive backed by threading.Condition."""
+
+    def __init__(self):
+        self._condition = threading.Condition()
+
+    def __enter__(self) -> None:
+        self._condition.acquire()
+
+    def __exit__(self, *args) -> None:
+        self._condition.release()
+
+    def wait_for(self, predicate: Callable[[], bool]) -> None:
+        self._condition.wait_for(predicate)
+
+    def notify_all(self) -> None:
+        self._condition.notify_all()
+
+
+class _ThreadWorker:
+    """Worker handle backed by threading.Thread."""
+
+    def __init__(
+        self, target: Callable[[], None], name: str, daemon: bool = True
+    ):
+        self._thread = threading.Thread(target=target, name=name, daemon=daemon)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def join(self, timeout: float | None = None) -> None:
+        self._thread.join(timeout=timeout)
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    @property
+    def native_thread(self) -> threading.Thread:
+        return self._thread
+
+
+class ThreadingTransport:
+    """
+    Default transport backend, based on real OS threads.
+
+    This backend preserves the current concurrency model of `Node` and
+    `Buffer`: every worker runs on its own `threading.Thread`, and queues
+    are backed by `queue.Queue`.
+    """
+
+    def new_queue(self, maxsize: int = 0) -> _ThreadQueue:
+        return _ThreadQueue(maxsize)
+
+    def new_signal(self) -> _ThreadSignal:
+        return _ThreadSignal()
+
+    def new_lock(self) -> _ThreadLock:
+        return _ThreadLock()
+
+    def new_condition(self) -> _ThreadCondition:
+        return _ThreadCondition()
+
+    def spawn(
+        self, target: Callable[[], None], name: str, daemon: bool = True
+    ) -> _ThreadWorker:
+        return _ThreadWorker(target, name, daemon)
+
+    def is_current(self, handle: WorkerHandle) -> bool:
+        if not isinstance(handle, _ThreadWorker):
+            return False
+
+        return threading.current_thread() is handle.native_thread


### PR DESCRIPTION
## Description

Introduces an injectable `TransportBackend` abstraction that decouples `Node/Buffer` concurrency from a hardcoded dependency on threading/queue. Adds `ThreadingTransport` as the default, behavior-preserving implementation. This is groundwork for alternative concurrency backends (e.g. a future browser/Pyodide-based transport) without changing any node's business logic.

## PR type
- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Test update
- [ ] Build/CI configuration change
- [ ] Other

## Key modifications and changes

- New `juturna/transport/` package:
  - `_base.py` - Queue, Signal, Lock, Condition, WorkerHandle Protocols plus the TransportBackend Protocol they compose into.
  - `_threading.py` - ThreadingTransport, backed by real threading.Thread/queue.Queue; reproduces the exact prior behavior.
  - `_registry.py` - get_transport(name) resolves a backend by name, defaulting to 'threading'.

- Node and Buffer no longer import threading/queue directly; both accept an optional transport: `TransportBackend` argument (falling back to `ThreadingTransport`()) and use it for queues, signals, locks, conditions, and spawning `_worker/_update/_source/_handle_control`.
- Pipeline resolves the backend once via `get_transport(config['pipeline'].get('transport'))` and threads it through node construction (`_node_builder._get_node` > `_builder_internal.build_component` / `_builder_external.build_node`), so every node in a pipeline shares the same backend.
- No behavioral change for existing users: the default backend is `ThreadingTransport`.

## Affected components

- Juturna core library - new `juturna/transport/` package; 
- `juturna/components/_node.py, _buffer.py, _pipeline.py _node_builder/_builder.py, _builder_external.py, _builder_internal.py`.

## Additional context

This PR only introduces the abstraction and its default (threading) implementation - no new backend ships here. It lays groundwork for a future alternative transport (e.g. running a pipeline inside a browser tab via Pyodide); design and feasibility spikes for that are tracked separately and are not part of this change.

Furthermore, I added a registry to list and access transport mode causes. IMHO, they shouldn't be pluggable at runtime yet, so I don't want to overcomplicate things with reflection and the like.