### PR TITLE
Cyclic pipes detection

### DIFF
--- a/juturna/components/_pipeline.py
+++ b/juturna/components/_pipeline.py
@@ -200,6 +200,11 @@ class Pipeline:
             self._links.append(copy.copy(link))
             self._dag.add_edge(from_node, to_node)
 
+        if self._dag.has_cycle():
+            raise ValueError(
+                f'pipe {self.name} contains a cycle: {self._dag.edges}'
+            )
+
         for node_name, node in self._nodes.items():
             node.warmup()
 
@@ -241,6 +246,15 @@ class Pipeline:
 
         if self._telemetry:
             self._telemetry_manager.start()
+
+        layers = self._dag.BFS()
+        scheduled = {n for layer in layers for n in layer}
+
+        if scheduled != set(self._nodes):
+            raise RuntimeError(
+                f'pipe {self.name} cannot start all nodes, '
+                f'{sorted(set(self._nodes) - scheduled)} are unreachable'
+            )
 
         for layer in self._dag.BFS()[::-1]:
             for node_name in layer:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -16,6 +16,9 @@ with open(pathlib.Path(test_pipelines, 'test_empty_pipeline.json'), 'r') as f:
 with open(pathlib.Path(test_pipelines, 'test_audio_pipeline.json'), 'r') as f:
     audio_config = json.load(f)
 
+with open(pathlib.Path(test_pipelines, 'test_cyclic_pipeline.json'), 'r') as f:
+    cyclic_config = json.load(f)
+
 
 def test_pipeline_base():
     test_pipeline = jt.components.Pipeline(empty_config)
@@ -74,3 +77,10 @@ def test_pipeline_base_stop_not_running():
         test_pipeline.stop()
 
     assert str(exc_info.value) == 'pipeline test_basic_pipeline is not running'
+
+
+def test_cyclic_pipeline_is_rejected_at_warmup():
+    test_pipeline = jt.components.Pipeline(cyclic_config)
+
+    with pytest.raises(ValueError, match='cycle'):
+        test_pipeline.warmup()

--- a/tests/test_pipelines/test_cyclic_pipeline.json
+++ b/tests/test_pipelines/test_cyclic_pipeline.json
@@ -1,0 +1,68 @@
+{
+  "version": "0.1.0",
+  "plugins": ["./plugins"],
+  "pipeline": {
+    "name": "test_audio_pipeline",
+    "id": "1234567890",
+    "folder": "./tests/running_pipelines/audio_pipeline",
+    "nodes": [
+      {
+        "name": "0_src",
+        "type": "source",
+        "mark": "audio_rtp",
+        "configuration": {
+          "rec_host": "127.0.0.1",
+          "rec_port": 123456,
+          "audio_rate": 16000,
+          "block_size": 2,
+          "channels": 2,
+          "payload_type": 97
+        }
+      },
+      {
+        "name": "1_idx",
+        "type": "proc",
+        "mark": "passthrough_identity",
+        "configuration": {
+          "delay": 1
+        }
+      },
+      {
+        "name": "2_idx",
+        "type": "proc",
+        "mark": "passthrough_identity",
+        "configuration": {
+          "delay": 1
+        }
+      },
+      {
+        "name": "3_dst",
+        "type": "sink",
+        "mark": "notifier_http",
+        "configuration": {
+          "endpoint": "http://127.0.0.1:1237",
+          "timeout": 5,
+          "content_type": "application/json"
+        }
+      }
+    ],
+    "links": [
+      {
+        "from": "0_src",
+        "to": "1_idx"
+      },
+      {
+        "from": "1_idx",
+        "to": "2_idx"
+      },
+      {
+        "from": "2_idx",
+        "to": "3_dst"
+      },
+      {
+        "from": "2_idx",
+        "to": "1_idx"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description
In this PR a check for cyclic pipelines is added to the `warmup`, so that pipelines that contain cycles are not partially initialized, while unreachable nodes are left hanging. Similarly, the `start` method now checks if there are unreachable nodes, and if so raises an exception.

**PR type**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update

### Affected components
This change does not impact significantly any of the components. However, the `warmup` and the `start` method can now raise a `ValueError` and a `RuntimeError` respectively, if the loaded pipeline contains cycles.